### PR TITLE
Parse chain ids from hex to dec instead of mapping them

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -3,7 +3,7 @@ import { NetworkState } from '@metamask/controllers';
 import SmartTransactionsController, {
   DEFAULT_INTERVAL,
 } from './SmartTransactionsController';
-import { API_BASE_URL, CHAIN_IDS, CHAIN_IDS_HEX_TO_DEC } from './constants';
+import { API_BASE_URL, CHAIN_IDS } from './constants';
 import { SmartTransaction, SmartTransactionStatuses } from './types';
 
 const confirmExternalMock = jest.fn();
@@ -195,7 +195,7 @@ const testHistory = [
   },
 ];
 
-const ethereumChainIdDec = CHAIN_IDS_HEX_TO_DEC[CHAIN_IDS.ETHEREUM];
+const ethereumChainIdDec = parseInt(CHAIN_IDS.ETHEREUM, 16);
 
 const trackMetaMetricsEventSpy = jest.fn();
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,8 +4,3 @@ export const CHAIN_IDS = {
   RINKEBY: '0x4',
   BSC: '0x38',
 };
-export const CHAIN_IDS_HEX_TO_DEC = {
-  [CHAIN_IDS.ETHEREUM]: '1',
-  [CHAIN_IDS.RINKEBY]: '4',
-  [CHAIN_IDS.BSC]: '56',
-} as any;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,7 +5,7 @@ import {
   SmartTransactionStatuses,
   SmartTransactionCancellationReason,
 } from './types';
-import { API_BASE_URL, CHAIN_IDS, CHAIN_IDS_HEX_TO_DEC } from './constants';
+import { API_BASE_URL, CHAIN_IDS } from './constants';
 
 describe('src/utils.js', () => {
   describe('isSmartTransactionPending', () => {
@@ -30,7 +30,7 @@ describe('src/utils.js', () => {
   });
 
   describe('getAPIRequestURL', () => {
-    const ethereumChainIdDec = CHAIN_IDS_HEX_TO_DEC[CHAIN_IDS.ETHEREUM];
+    const ethereumChainIdDec = parseInt(CHAIN_IDS.ETHEREUM, 16);
 
     it('returns a URL for getting transactions', () => {
       expect(utils.getAPIRequestURL(APIType.GET_FEES, CHAIN_IDS.ETHEREUM)).toBe(
@@ -65,7 +65,7 @@ describe('src/utils.js', () => {
     });
 
     it('returns a URL for smart transactions API liveness for the BSC chainId', () => {
-      const bscChainIdDec = CHAIN_IDS_HEX_TO_DEC[CHAIN_IDS.BSC];
+      const bscChainIdDec = parseInt(CHAIN_IDS.BSC, 16);
       expect(utils.getAPIRequestURL(APIType.LIVENESS, CHAIN_IDS.BSC)).toBe(
         `${API_BASE_URL}/networks/${bscChainIdDec}/health`,
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import {
   SmartTransactionMinedTx,
   cancellationReasonToStatusMap,
 } from './types';
-import { API_BASE_URL, CHAIN_IDS_HEX_TO_DEC } from './constants';
+import { API_BASE_URL } from './constants';
 
 export function isSmartTransactionPending(smartTransaction: SmartTransaction) {
   return smartTransaction.status === SmartTransactionStatuses.PENDING;
@@ -21,7 +21,7 @@ export const isSmartTransactionStatusResolved = (
 
 // TODO use actual url once API is defined
 export function getAPIRequestURL(apiType: APIType, chainId: string): string {
-  const chainIdDec = CHAIN_IDS_HEX_TO_DEC[chainId];
+  const chainIdDec = parseInt(chainId, 16);
   switch (apiType) {
     case APIType.GET_FEES: {
       return `${API_BASE_URL}/networks/${chainIdDec}/getFees`;


### PR DESCRIPTION
This solution is more extensible for new networks and fixes a bug where unsupported networks are sent to the transaction api as `undefined`.