### PR TITLE
Add config for `MetaMask/action-npm-publish`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,17 +1,33 @@
 name: Publish Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [main]
 
 jobs:
+  check-release:
+    # release merge commits come from GitHub user
+    if: github.event.head_commit.committer.name == 'GitHub'
+    outputs:
+      IS_RELEASE: ${{ steps.check-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+          # we need this commit + the last so we can compare below
+          fetch-depth: 2
+      # exit early if the version has not changed
+      - name: Check Release
+        id: check-release
+        run: ./scripts/check-release.sh ${{ github.event.before }}
+
   publish-release:
     permissions:
       contents: write
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+    if: needs.check-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
+    needs: check-release
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,6 +40,53 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@v1
+      - uses: MetaMask/action-publish-release@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install
+        run: |
+          yarn install
+          yarn build
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+
+  publish-npm-dry-run:
+    runs-on: ubuntu-latest
+    needs: publish-release
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
+      - run: npm config set ignore-scripts true
+      - name: Dry Run Publish
+        # omit npm-token token to perform dry run publish
+        uses: MetaMask/action-npm-publish@v1.1.0
+
+  publish-npm:
+    environment: npm-publish
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
+      - run: npm config set ignore-scripts true
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v1.1.0
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+BEFORE="${1}"
+
+if [[ -z $BEFORE ]]; then
+  echo "Error: Before SHA not specified."
+  exit 1
+fi
+
+VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
+VERSION_AFTER="$(jq --raw-output .version package.json)"
+if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
+  echo "Notice: version unchanged. Skipping release."
+  echo "::set-output name=IS_RELEASE::false"
+  exit 0
+fi
+ 
+echo "::set-output name=IS_RELEASE::true"


### PR DESCRIPTION
This PR adds config so that we can automatically deploy packages to npm on release.

Opening as a Draft for now until the `environment` (`npm-publish`) is configured.

I've tested this in my fork here: https://github.com/rickycodes/smart-transactions-controller/actions/runs/2667509178

TODO:
- [x] set up `npm-publish` environment with `NPM_TOKEN` secret