### PR TITLE
Remove unnecessary event props

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -230,11 +230,8 @@ export default class SmartTransactionsController extends BaseController<
     }
 
     const sensitiveProperties = {
-      uuid: updatedSmartTransaction.uuid,
       stx_status: updatedSmartTransaction.status,
-      token_from_address: updatedSmartTransaction.txParams?.from,
       token_from_symbol: updatedSmartTransaction.sourceTokenSymbol,
-      token_to_address: updatedSmartTransaction.txParams?.to,
       token_to_symbol: updatedSmartTransaction.destinationTokenSymbol,
       processing_time: getStxProcessingTime(updatedSmartTransaction.time),
       stx_enabled: true,


### PR DESCRIPTION
## Description
This PR removes unnecessary props, which are no longer needed for making our product better. We added them initially because we thought they could be useful for debugging. We have also just noticed that token_from_address and token_to_address fields don't even use correct values. All these 3 event props are not needed, so we are removing them and we will also clean them up in our database. This issue affected a small subset of users who opted in MetaMetrics and submitted transactions through our embedded Swaps feature with Smart Transactions enabled. 

If you think we have somewhere in MM an unnecessary event prop, let us please know via GitHub issue.