### PR TITLE
Remove `getNetwork` option

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -535,7 +535,7 @@ describe('SmartTransactionsController', () => {
             [chainIdHex]: [
               expect.objectContaining({
                 chainId: chainIdHex,
-                metamaskNetworkId: chainIdDec.toString(),
+                metamaskNetworkId: chainIdDec,
                 uuid,
                 history: [
                   expect.objectContaining({

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -503,8 +503,8 @@ describe('SmartTransactionsController', () => {
 
   describe('submitSignedTransactions', () => {
     it('submits a smart transaction with signed transactions', async () => {
+      const chainIdDec = '100';
       const chainIdHex = '0x64';
-      const chainIdDec = 100;
       const uuid = 'abc123';
 
       await withController(

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -540,7 +540,7 @@ describe('SmartTransactionsController', () => {
                 history: [
                   expect.objectContaining({
                     chainId: chainIdHex,
-                    metamaskNetworkId: chainIdDec.toString(),
+                    metamaskNetworkId: chainIdDec,
                     uuid,
                   }),
                 ],

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -266,7 +266,6 @@ describe('SmartTransactionsController', () => {
           releaseLock: jest.fn(),
         };
       }),
-      getNetwork: jest.fn(() => '1'),
       provider: jest.fn(),
       confirmExternalTransaction: confirmExternalMock,
       trackMetaMetricsEvent: trackMetaMetricsEventSpy,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -66,8 +66,6 @@ export default class SmartTransactionsController extends BaseController<
 
   private getNonceLock: any;
 
-  private getNetwork: any;
-
   public ethersProvider: any;
 
   public confirmExternalTransaction: any;
@@ -92,7 +90,6 @@ export default class SmartTransactionsController extends BaseController<
     {
       onNetworkStateChange,
       getNonceLock,
-      getNetwork,
       provider,
       confirmExternalTransaction,
       trackMetaMetricsEvent,
@@ -101,7 +98,6 @@ export default class SmartTransactionsController extends BaseController<
         listener: (networkState: NetworkState) => void,
       ) => void;
       getNonceLock: any;
-      getNetwork: any;
       provider: any;
       confirmExternalTransaction: any;
       trackMetaMetricsEvent: any;
@@ -131,7 +127,6 @@ export default class SmartTransactionsController extends BaseController<
     };
 
     this.getNonceLock = getNonceLock;
-    this.getNetwork = getNetwork;
     this.ethersProvider = new Web3Provider(provider);
     this.confirmExternalTransaction = confirmExternalTransaction;
     this.trackMetaMetricsEvent = trackMetaMetricsEvent;
@@ -555,7 +550,6 @@ export default class SmartTransactionsController extends BaseController<
       },
     );
     const time = Date.now();
-    const metamaskNetworkId = this.getNetwork();
     let preTxBalance;
     try {
       const preTxBalanceBN = await this.ethersProvider.getBalance(
@@ -576,7 +570,7 @@ export default class SmartTransactionsController extends BaseController<
       this.updateSmartTransaction({
         chainId,
         nonceDetails,
-        metamaskNetworkId,
+        metamaskNetworkId: chainId.replace(/^0x/u, ''),
         preTxBalance,
         status: SmartTransactionStatuses.PENDING,
         time,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -570,7 +570,7 @@ export default class SmartTransactionsController extends BaseController<
       this.updateSmartTransaction({
         chainId,
         nonceDetails,
-        metamaskNetworkId: chainId.replace(/^0x/u, ''),
+        metamaskNetworkId: new BigNumber(chainId, 16).toString(10),
         preTxBalance,
         status: SmartTransactionStatuses.PENDING,
         time,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,6 @@ describe('default export', () => {
       onNetworkStateChange: jest.fn(),
       getNonceLock: null,
       provider: jest.fn(),
-      getNetwork: jest.fn(() => '1'),
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
     });


### PR DESCRIPTION
Currently NetworkController captures the network ID of the currently selected network via the `net_version` RPC method. However, as it is not part of the Ethereum spec, `net_version` is not guaranteed to be supported across all EVM chains; we can safely use chain ID as a replacement for network ID instead. For this reason, we plan on removing this captured network ID from NetworkController.

The `getNetwork` option to SmartTransactionController was intended to get the network ID as stored by NetworkController, but if we are removing that, then we no longer need this option.

This is a **breaking** change.

---

For more context, see: https://github.com/MetaMask/metamask-extension/issues/16946.