### PR TITLE
deps: @metamask/* updates

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
   // original implementations, between each test. It does not affect mocked
   // modules.
   restoreMocks: true,
+  setupFiles: ['./setupJest.js'],
   testEnvironment: 'node',
   testRegex: ['\\.test\\.(ts|js)$'],
   testTimeout: 2500,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/lodash": "^4.14.176",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
-    "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
@@ -55,8 +54,9 @@
     "eslint-plugin-jest": "^24.3.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "isomorphic-fetch": "^3.0.0",
     "jest": "^26.4.2",
-    "nock": "^13.1.3",
+    "nock": "^13.3.0",
     "prettier": "^2.2.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-unassigned-import
+require('isomorphic-fetch');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-unassigned-import
-import 'isomorphic-fetch';
 import SmartTransactionsController from './SmartTransactionsController';
 
 export default SmartTransactionsController;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,11 +4499,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4753,14 +4748,14 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nock@^13.1.3:
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.1.3.tgz#110b005965654a8ffb798e87bad18b467bff15f9"
-  integrity sha512-YKj0rKQWMGiiIO+Y65Ut8OEgYM3PplLU2+GAhnPmqZdBd6z5IskgdBqWmjzA6lH3RF0S2a3wiAlrMOF5Iv2Jeg==
+nock@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
+  integrity sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
+    lodash "^4.17.21"
     propagate "^2.0.0"
 
 node-addon-api@^2.0.0:


### PR DESCRIPTION
### Changes
 - Remove `isomorphic-fetch` from runtime dependencies - runtime lacking `fetch` implementation now have to supply their own polyfill.
 - Upgrade packages
   - `@metamask/base-controller`@`1.0.0`->`2.0.0` 
   - `@metamask/controller-utils`@`1.0.0`->`3.3.0` 
   - `@metamask/network-controller`@`2.0.0`->`7.0.0` 

### Unifies:
- #122 
- #128 
- #130 
