### PR TITLE
Replace placeholders in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `@metamask/smart-transactions-controller`
 
-MetaMask controller for Smart Transactions.
+Improves success rates for swaps by trialing transactions privately and finding minimum fees.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
-# MetaMask Module Template
+# `@metamask/smart-transactions-controller`
 
-This TypeScript module is maintained in the style of the MetaMask team.
+MetaMask controller for Smart Transactions.
 
 ## Installation
 
-`yarn add @metamask/this-module`
+`yarn add @metamask/smart-transactions-controller`
 
 or
 
-`npm install @metamask/this-module`
-
-## Usage
-
-_Add examples here_
-
-## API
-
-_Add examples here_
+`npm install @metamask/smart-transactions-controller`
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/smart-transactions-controller",
   "version": "3.1.0",
-  "description": "MetaMask controller for Smart Transactions.",
+  "description": "Improves success rates for swaps by trialing transactions privately and finding minimum fees",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/smart-transactions-controller.git"


### PR DESCRIPTION
The module template README contains placeholder content that is designed to be replaced when a new library is created from the template. This updates the README to suit this library.