### PR TITLE
Remove networkId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING:** Bump dependency on `@metamask/network-controller` to ^13.0.0 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
+- Bump dependency on `@metamask/base-controller` to ^3.2.1 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
+- Bump dependency on `@metamask/controller-utils` to ^5.0.0 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
+
+### Removed
+- **BREAKING:** Remove  `metamaskNetworkId` from smart transaction state ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
+- Remove `getNetwork` from constructor options ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
 
 ## [4.0.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- **BREAKING:** Bump dependency on `@metamask/network-controller` to ^13.0.0 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
+- Bump dependency on `@metamask/network-controller` to ^13.0.0 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
 - Bump dependency on `@metamask/base-controller` to ^3.2.1 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
 - Bump dependency on `@metamask/controller-utils` to ^5.0.0 ([#191](https://github.com/MetaMask/smart-transactions-controller/pull/191))
 

--- a/package.json
+++ b/package.json
@@ -24,17 +24,13 @@
     "test": "jest",
     "test:watch": "jest --watchAll"
   },
-  "resolutions": {
-    "@metamask/controller-utils@^4.1.0": "npm:@metamask-previews/controller-utils@4.3.1-preview.3dbf14f",
-    "@metamask/network-controller@^10.3.0": "npm:@metamask-previews/network-controller@12.1.1-preview.3dbf14f"
-  },
   "dependencies": {
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
-    "@metamask/base-controller": "^3.0.0",
-    "@metamask/controller-utils": "^4.1.0",
-    "@metamask/network-controller": "^10.3.0",
+    "@metamask/base-controller": "^3.2.1",
+    "@metamask/controller-utils": "^5.0.0",
+    "@metamask/network-controller": "^13.0.0",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "test": "jest",
     "test:watch": "jest --watchAll"
   },
+  "resolutions": {
+    "@metamask/controller-utils@^4.1.0": "npm:@metamask-previews/controller-utils@4.3.1-preview.3dbf14f",
+    "@metamask/network-controller@^10.3.0": "npm:@metamask-previews/network-controller@12.1.1-preview.3dbf14f"
+  },
   "dependencies": {
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -266,7 +266,6 @@ describe('SmartTransactionsController', () => {
           releaseLock: jest.fn(),
         };
       }),
-      getNetwork: jest.fn(() => '1'),
       provider: jest.fn(),
       confirmExternalTransaction: confirmExternalMock,
       trackMetaMetricsEvent: trackMetaMetricsEventSpy,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -554,7 +554,6 @@ export default class SmartTransactionsController extends BaseController<
       },
     );
     const time = Date.now();
-    const metamaskNetworkId = this.getNetwork();
     let preTxBalance;
     try {
       const preTxBalanceBN = await this.ethersProvider.getBalance(
@@ -575,7 +574,6 @@ export default class SmartTransactionsController extends BaseController<
       this.updateSmartTransaction({
         chainId,
         nonceDetails,
-        metamaskNetworkId,
         preTxBalance,
         status: SmartTransactionStatuses.PENDING,
         time,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -66,8 +66,6 @@ export default class SmartTransactionsController extends BaseController<
 
   private getNonceLock: any;
 
-  private getNetwork: any;
-
   public ethersProvider: any;
 
   public confirmExternalTransaction: any;
@@ -92,7 +90,6 @@ export default class SmartTransactionsController extends BaseController<
     {
       onNetworkStateChange,
       getNonceLock,
-      getNetwork,
       provider,
       confirmExternalTransaction,
       trackMetaMetricsEvent,
@@ -101,7 +98,6 @@ export default class SmartTransactionsController extends BaseController<
         listener: (networkState: NetworkState) => void,
       ) => void;
       getNonceLock: any;
-      getNetwork: any;
       provider: any;
       confirmExternalTransaction: any;
       trackMetaMetricsEvent: any;
@@ -131,7 +127,6 @@ export default class SmartTransactionsController extends BaseController<
     };
 
     this.getNonceLock = getNonceLock;
-    this.getNetwork = getNetwork;
     this.ethersProvider = new Web3Provider(provider);
     this.confirmExternalTransaction = confirmExternalTransaction;
     this.trackMetaMetricsEvent = trackMetaMetricsEvent;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,6 @@ describe('default export', () => {
       onNetworkStateChange: jest.fn(),
       getNonceLock: null,
       provider: jest.fn(),
-      getNetwork: jest.fn(() => '1'),
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,6 @@ export type SmartTransaction = {
   destinationTokenDecimals?: string;
   destinationTokenSymbol?: string;
   history?: any;
-  metamaskNetworkId?: string;
   nonceDetails?: any;
   origin?: string;
   preTxBalance?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,32 +1117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask-previews/base-controller@npm:3.2.0-preview.3dbf14f":
-  version: 3.2.0-preview.3dbf14f
-  resolution: "@metamask-previews/base-controller@npm:3.2.0-preview.3dbf14f"
-  dependencies:
-    "@metamask/utils": ^6.2.0
-    immer: ^9.0.6
-  checksum: f7d359f31c65273eec95405d31f64618d6d8b5641fbda3de53806d4eaaac71a8c7715642300c36e694fcc3aadb989551363611e8714bb2c5308c6007d2d3fb15
-  languageName: node
-  linkType: hard
-
-"@metamask-previews/controller-utils@npm:4.3.1-preview.3dbf14f, @metamask/controller-utils@npm:@metamask-previews/controller-utils@4.3.1-preview.3dbf14f":
-  version: 4.3.1-preview.3dbf14f
-  resolution: "@metamask-previews/controller-utils@npm:4.3.1-preview.3dbf14f"
-  dependencies:
-    "@metamask/eth-query": ^3.0.1
-    "@metamask/utils": ^6.2.0
-    "@spruceid/siwe-parser": 1.1.3
-    eth-ens-namehash: ^2.0.8
-    eth-rpc-errors: ^4.0.2
-    ethereumjs-util: ^7.0.10
-    ethjs-unit: ^0.1.6
-    fast-deep-equal: ^3.1.3
-  checksum: 2ab29816be29de54b754d8c53631a709d4b51b5ba5b5fc2723e8de2c4df0dd2d3cabc7e3205ab1955958986c7ac46ff4118b670f73b2384217958e170b87dc66
-  languageName: node
-  linkType: hard
-
 "@metamask/abi-utils@npm:^1.2.0":
   version: 1.2.0
   resolution: "@metamask/abi-utils@npm:1.2.0"
@@ -1167,13 +1141,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.0.0":
+"@metamask/base-controller@npm:^3.2.1":
   version: 3.2.1
   resolution: "@metamask/base-controller@npm:3.2.1"
   dependencies:
     "@metamask/utils": ^6.2.0
     immer: ^9.0.6
   checksum: 73723a275ad2c8c6f9fcfcd69fd8b469bf8f4455fc572fc19ac9a8d76e5b65152cb111d95bfb9a4b9443298147e03a5f9778747dec2ca2203495ace54c97688c
+  languageName: node
+  linkType: hard
+
+"@metamask/controller-utils@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@metamask/controller-utils@npm:5.0.0"
+  dependencies:
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/utils": ^6.2.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    ethjs-unit: ^0.1.6
+    fast-deep-equal: ^3.1.3
+  checksum: ca1a9f09caba5bc80ea63bc9f12aca0e8532d6e6062469085feead735ef75c9532aee025dec50c25e425635594c2c148f0809da1c35f3932a2d0997be0190170
   languageName: node
   linkType: hard
 
@@ -1239,7 +1229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^11.0.0":
+"@metamask/eth-json-rpc-middleware@npm:^11.0.2":
   version: 11.0.2
   resolution: "@metamask/eth-json-rpc-middleware@npm:11.0.2"
   dependencies:
@@ -1291,14 +1281,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@12.1.1-preview.3dbf14f":
-  version: 12.1.1-preview.3dbf14f
-  resolution: "@metamask-previews/network-controller@npm:12.1.1-preview.3dbf14f"
+"@metamask/network-controller@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@metamask/network-controller@npm:13.0.0"
   dependencies:
-    "@metamask-previews/base-controller": 3.2.0-preview.3dbf14f
-    "@metamask-previews/controller-utils": 4.3.1-preview.3dbf14f
+    "@metamask/base-controller": ^3.2.1
+    "@metamask/controller-utils": ^5.0.0
     "@metamask/eth-json-rpc-infura": ^8.1.1
-    "@metamask/eth-json-rpc-middleware": ^11.0.0
+    "@metamask/eth-json-rpc-middleware": ^11.0.2
     "@metamask/eth-json-rpc-provider": ^1.0.0
     "@metamask/eth-query": ^3.0.1
     "@metamask/swappable-obj-proxy": ^2.1.0
@@ -1309,7 +1299,7 @@ __metadata:
     immer: ^9.0.6
     json-rpc-engine: ^6.1.0
     uuid: ^8.3.2
-  checksum: e5add66f972d8961d6f6076ecccdaba364853743c80fe6c27b207f1e905737f74cbc7afeca539cd18d1376671160637cc358190bb1b935714330abcd551db508
+  checksum: bfe5024e4cd27295d145565b5ae6e8e8a7704670487120afd61c6b5f5c2106783f84736dd2d3e512bb0a7fb06e21635660cbb70af238c0165b0742f5b58a2243
   languageName: node
   linkType: hard
 
@@ -1336,13 +1326,13 @@ __metadata:
     "@ethersproject/providers": ^5.7.0
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/controller-utils": ^4.1.0
+    "@metamask/base-controller": ^3.2.1
+    "@metamask/controller-utils": ^5.0.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
-    "@metamask/network-controller": ^10.3.0
+    "@metamask/network-controller": ^13.0.0
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^16.18.31

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,6 +1106,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask-previews/base-controller@npm:3.2.0-preview.3dbf14f":
+  version: 3.2.0-preview.3dbf14f
+  resolution: "@metamask-previews/base-controller@npm:3.2.0-preview.3dbf14f"
+  dependencies:
+    "@metamask/utils": ^6.2.0
+    immer: ^9.0.6
+  checksum: f7d359f31c65273eec95405d31f64618d6d8b5641fbda3de53806d4eaaac71a8c7715642300c36e694fcc3aadb989551363611e8714bb2c5308c6007d2d3fb15
+  languageName: node
+  linkType: hard
+
+"@metamask-previews/controller-utils@npm:4.3.1-preview.3dbf14f, @metamask/controller-utils@npm:@metamask-previews/controller-utils@4.3.1-preview.3dbf14f":
+  version: 4.3.1-preview.3dbf14f
+  resolution: "@metamask-previews/controller-utils@npm:4.3.1-preview.3dbf14f"
+  dependencies:
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/utils": ^6.2.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    ethjs-unit: ^0.1.6
+    fast-deep-equal: ^3.1.3
+  checksum: 2ab29816be29de54b754d8c53631a709d4b51b5ba5b5fc2723e8de2c4df0dd2d3cabc7e3205ab1955958986c7ac46ff4118b670f73b2384217958e170b87dc66
+  languageName: node
+  linkType: hard
+
 "@metamask/auto-changelog@npm:^3.1.0":
   version: 3.2.0
   resolution: "@metamask/auto-changelog@npm:3.2.0"
@@ -1127,23 +1153,6 @@ __metadata:
     "@metamask/utils": ^6.2.0
     immer: ^9.0.6
   checksum: 3be6f2594309c013e07f83c4bb8271e1e99f02b6ff829c18b5e7218fbab4e6a9e03bcb49056704ce47f84ae2f38b1bc1c10284ec538aad56ed7b554ef2d3e189
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "@metamask/controller-utils@npm:4.2.0"
-  dependencies:
-    "@metamask/utils": ^5.0.2
-    "@spruceid/siwe-parser": 1.1.3
-    babel-runtime: ^6.26.0
-    eth-ens-namehash: ^2.0.8
-    eth-query: ^2.1.2
-    eth-rpc-errors: ^4.0.2
-    ethereumjs-util: ^7.0.10
-    ethjs-unit: ^0.1.6
-    fast-deep-equal: ^3.1.3
-  checksum: e71779577c37038e6e605a43ef6b9c1af82e0b3887a72c01f48ae1e4e2005116fc9d09c8b690139478c04dd2929e227642c5fd80cfbc81814d667c415c714228
   languageName: node
   linkType: hard
 
@@ -1196,7 +1205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-infura@npm:^8.0.0":
+"@metamask/eth-json-rpc-infura@npm:^8.1.1":
   version: 8.1.1
   resolution: "@metamask/eth-json-rpc-infura@npm:8.1.1"
   dependencies:
@@ -1236,6 +1245,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-query@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@metamask/eth-query@npm:3.0.1"
+  dependencies:
+    json-rpc-random-id: ^1.0.0
+    xtend: ^4.0.1
+  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-sig-util@npm:^5.0.0":
   version: 5.1.0
   resolution: "@metamask/eth-sig-util@npm:5.1.0"
@@ -1250,26 +1269,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "@metamask/network-controller@npm:10.3.0"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@12.1.1-preview.3dbf14f":
+  version: 12.1.1-preview.3dbf14f
+  resolution: "@metamask-previews/network-controller@npm:12.1.1-preview.3dbf14f"
   dependencies:
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/controller-utils": ^4.1.0
-    "@metamask/eth-json-rpc-infura": ^8.0.0
+    "@metamask-previews/base-controller": 3.2.0-preview.3dbf14f
+    "@metamask-previews/controller-utils": 4.3.1-preview.3dbf14f
+    "@metamask/eth-json-rpc-infura": ^8.1.1
     "@metamask/eth-json-rpc-middleware": ^11.0.0
     "@metamask/eth-json-rpc-provider": ^1.0.0
+    "@metamask/eth-query": ^3.0.1
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": ^5.0.2
+    "@metamask/utils": ^6.2.0
     async-mutex: ^0.2.6
-    babel-runtime: ^6.26.0
     eth-block-tracker: ^7.0.1
-    eth-query: ^2.1.2
     eth-rpc-errors: ^4.0.2
     immer: ^9.0.6
     json-rpc-engine: ^6.1.0
     uuid: ^8.3.2
-  checksum: 0c48625af9c18be3ed2a433209db770bab02e667e251be1ef4c1f61a62c25907536ff740712bdfd799ac923a4a6bb9df5430ead8d4215507bbf30dcc7a40d53c
+  checksum: e5add66f972d8961d6f6076ecccdaba364853743c80fe6c27b207f1e905737f74cbc7afeca539cd18d1376671160637cc358190bb1b935714330abcd551db508
   languageName: node
   linkType: hard
 
@@ -1347,7 +1365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^5.0.1, @metamask/utils@npm:^5.0.2":
+"@metamask/utils@npm:^5.0.1":
   version: 5.0.2
   resolution: "@metamask/utils@npm:5.0.2"
   dependencies:
@@ -2307,16 +2325,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-runtime@npm:^6.26.0":
-  version: 6.26.0
-  resolution: "babel-runtime@npm:6.26.0"
-  dependencies:
-    core-js: ^2.4.0
-    regenerator-runtime: ^0.11.0
-  checksum: 8aeade94665e67a73c1ccc10f6fd42ba0c689b980032b70929de7a6d9a12eb87ef51902733f8fefede35afea7a5c3ef7e916a64d503446c1eedc9e3284bd3d50
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.0
   resolution: "balanced-match@npm:1.0.0"
@@ -2902,13 +2910,6 @@ __metadata:
   version: 0.1.1
   resolution: "copy-descriptor@npm:0.1.1"
   checksum: d4b7b57b14f1d256bb9aa0b479241048afd7f5bcf22035fc7b94e8af757adeae247ea23c1a774fe44869fd5694efba4a969b88d966766c5245fdee59837fe45b
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^2.4.0":
-  version: 2.6.12
-  resolution: "core-js@npm:2.6.12"
-  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
   languageName: node
   linkType: hard
 
@@ -3762,16 +3763,6 @@ __metadata:
     idna-uts46-hx: ^2.3.1
     js-sha3: ^0.5.7
   checksum: 40ce4aeedaa4e7eb4485c8d8857457ecc46a4652396981d21b7e3a5f922d5beff63c71cb4b283c935293e530eba50b329d9248be3c433949c6bc40c850c202a3
-  languageName: node
-  linkType: hard
-
-"eth-query@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "eth-query@npm:2.1.2"
-  dependencies:
-    json-rpc-random-id: ^1.0.0
-    xtend: ^4.0.1
-  checksum: 83daa0e28452c54722aec78cd24d036bad5b6e7c08035d98e10d4bea11f71662f12cab63ebd8a848d4df46ad316503d54ecccb41c9244d2ea8b29364b0a20201
   languageName: node
   linkType: hard
 
@@ -7285,13 +7276,6 @@ __metadata:
     string_decoder: ^1.1.1
     util-deprecate: ^1.0.1
   checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.11.0":
-  version: 0.11.1
-  resolution: "regenerator-runtime@npm:0.11.1"
-  checksum: 3c97bd2c7b2b3247e6f8e2147a002eb78c995323732dad5dc70fac8d8d0b758d0295e7015b90d3d444446ae77cbd24b9f9123ec3a77018e81d8999818301b4f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Wallets shouldn't be directly concerned about the network ID as this more of a p2p concept for gossip. What wallets really care about is chain ID as that is the correct value to use to identify a chain, build transactions, etc. Although these two values usually match (ignoring hex/dec formatting), there are [exceptions](https://medium.com/@pedrouid/chainid-vs-networkid-how-do-they-differ-on-ethereum-eec2ed41635b).

We want to remove usage of `networkId` from the SmartTransactionController.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
* See: https://github.com/MetaMask/metamask-extension/pull/20652/files
-->
* Fixes [mmp-1068](https://github.com/MetaMask/MetaMask-planning/issues/1068)
* See: [core-1633](https://github.com/MetaMask/core/pull/1633)
* See: https://github.com/MetaMask/metamask-extension/pull/20652