### PR TITLE
Parameterize SmartTransactionsController state by ChainId for MultiChain + Integrate PollingController Mixin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 77.35,
+      branches: 76.5,
       functions: 92.5,
       lines: 93.35,
       statements: 93.35,

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 78,
+      branches: 77.5,
       functions: 92.5,
-      lines: 94,
-      statements: 93.5,
+      lines: 93.35,
+      statements: 93.35,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 77,
-      functions: 89,
-      lines: 92,
-      statements: 91,
+      branches: 78,
+      functions: 92.5,
+      lines: 94,
+      statements: 93.5,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 77.4,
+      branches: 77.35,
       functions: 92.5,
       lines: 93.35,
       statements: 93.35,

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 77.5,
+      branches: 77.4,
       functions: 92.5,
       lines: 93.35,
       statements: 93.35,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^5.0.0",
     "@metamask/network-controller": "^15.0.0",
-    "@metamask/polling-controller": "^0.1.0",
+    "@metamask/polling-controller": "^0.2.0",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^5.0.0",
     "@metamask/network-controller": "^15.0.0",
+    "@metamask/polling-controller": "^0.1.0",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
-    "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
-    "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^5.0.0",
+    "@metamask/eth-query": "^3.0.1",
     "@metamask/network-controller": "^15.0.0",
     "@metamask/polling-controller": "^0.2.0",
     "bignumber.js": "^9.0.1",

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -29,7 +29,7 @@ jest.mock('@metamask/eth-query', () => {
     sendAsync = jest.fn(({ method }, callback) => {
       switch (method) {
         case 'getBalance': {
-          callback(null, { toHexString: () => '0x1000' });
+          callback(null, '0x1000');
           break;
         }
 
@@ -38,15 +38,15 @@ jest.mock('@metamask/eth-query', () => {
           break;
         }
 
-        case 'getBlock': {
-          callback(null, { baseFeePerGas: { toHexString: () => '0x123' } });
+        case 'getBlockByNumber': {
+          callback(null, { baseFeePerGas: '0x123' });
           break;
         }
 
         case 'getTransaction': {
           callback(null, {
-            maxFeePerGas: { toHexString: () => '0x123' },
-            maxPriorityFeePerGas: { toHexString: () => '0x123' },
+            maxFeePerGas: '0x123',
+            maxPriorityFeePerGas: '0x123',
           });
           break;
         }
@@ -731,7 +731,9 @@ describe('SmartTransactionsController', () => {
         [CHAIN_IDS.GOERLI]: true,
       });
 
-      await smartTransactionsController.fetchLiveness('goerli');
+      await smartTransactionsController.fetchLiveness({
+        networkClientId: 'goerli',
+      });
 
       expect(
         smartTransactionsController.state.smartTransactionsState
@@ -834,12 +836,6 @@ describe('SmartTransactionsController', () => {
     });
 
     it('throws an error if ethersProvider fails', async () => {
-      // smartTransactionsController.ethQuery.getTransactionReceipt.mockRejectedValueOnce(
-      //   'random error' as never,
-      // );
-      // jest.spyOn('@metmask/eth-query', 'sendAsync')(() => {
-      //   throw new Error('random error');
-      // });
       const successfulStx = {
         ...createStateAfterSuccess()[0],
         history: testHistory,

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -205,7 +205,6 @@ const createStateAfterPending = () => {
       uuid: 'uuid1',
       status: 'pending',
       cancellable: true,
-      chainId: '0x1',
       statusMetadata: {
         cancellationFeeWei: 0,
         cancellationReason: 'not_cancelled',
@@ -234,7 +233,6 @@ const createStateAfterSuccess = () => {
       uuid: 'uuid2',
       status: 'success',
       cancellable: false,
-      chainId: '0x1',
       statusMetadata: {
         cancellationFeeWei: 36777567771000,
         cancellationReason: 'not_cancelled',
@@ -661,6 +659,7 @@ describe('SmartTransactionsController', () => {
       };
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
+        CHAIN_IDS.ETHEREUM,
       );
 
       expect(
@@ -693,6 +692,7 @@ describe('SmartTransactionsController', () => {
       };
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
+        CHAIN_IDS.ETHEREUM,
       );
       expect(confirmSpy).toHaveBeenCalled();
     });
@@ -711,6 +711,7 @@ describe('SmartTransactionsController', () => {
       };
       await smartTransactionsController.confirmSmartTransaction(
         successfulStx as SmartTransaction,
+        CHAIN_IDS.ETHEREUM,
       );
       expect(confirmExternalMock).toHaveBeenCalled();
     });
@@ -724,7 +725,8 @@ describe('SmartTransactionsController', () => {
         history: testHistory,
       };
       await smartTransactionsController.confirmSmartTransaction(
-        successfulStx as SmartTransaction, 
+        successfulStx as SmartTransaction,
+        CHAIN_IDS.ETHEREUM,
       );
       expect(trackMetaMetricsEventSpy).toHaveBeenCalled();
     });

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -724,7 +724,7 @@ describe('SmartTransactionsController', () => {
         history: testHistory,
       };
       await smartTransactionsController.confirmSmartTransaction(
-        successfulStx as SmartTransaction,
+        successfulStx as SmartTransaction, 
       );
       expect(trackMetaMetricsEventSpy).toHaveBeenCalled();
     });

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -750,8 +750,7 @@ describe('SmartTransactionsController', () => {
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
         {
-          chainId: CHAIN_IDS.ETHEREUM,
-          ethersProvider: new Web3Provider(jest.fn()),
+          networkClientId: 'mainnet',
         },
       );
 
@@ -786,8 +785,7 @@ describe('SmartTransactionsController', () => {
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
         {
-          chainId: CHAIN_IDS.ETHEREUM,
-          ethersProvider: new Web3Provider(jest.fn()),
+          networkClientId: 'mainnet',
         },
       );
       expect(confirmSpy).toHaveBeenCalled();

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -961,40 +961,6 @@ describe('SmartTransactionsController', () => {
         ]),
       );
 
-      // TODO figure this out:
-      // having trouble getting the state to update in this test
-      // await jest.runOnlyPendingTimers();
-      // const pendingState = createStateAfterPending()[0];
-      // const pendingTransaction = { ...pendingState, history: [pendingState] };
-      // await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
-      // expect(smartTransactionsController.state).toStrictEqual({
-      //   smartTransactionsState: {
-      //     smartTransactions: {
-      //       [CHAIN_IDS.ETHEREUM]: [pendingTransaction],
-      //     },
-      //     userOptIn: undefined,
-      //     fees: {
-      //       approvalTxFees: undefined,
-      //       tradeTxFees: undefined,
-      //     },
-      //     feesByChainId: {
-      //       [CHAIN_IDS.ETHEREUM]: {
-      //         approvalTxFees: undefined,
-      //         tradeTxFees: undefined,
-      //       },
-      //       [CHAIN_IDS.GOERLI]: {
-      //         approvalTxFees: undefined,
-      //         tradeTxFees: undefined,
-      //       },
-      //     },
-      //     liveness: true,
-      //     livenessByChainId: {
-      //       [CHAIN_IDS.ETHEREUM]: true,
-      //       [CHAIN_IDS.GOERLI]: true,
-      //     },
-      //   },
-      // });
-
       // cleanup
       smartTransactionsController.update({
         smartTransactionsState: {

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import { NetworkState } from '@metamask/network-controller';
 import { convertHexToDecimal } from '@metamask/controller-utils';
+import { Web3Provider } from '@ethersproject/providers';
 import SmartTransactionsController, {
   DEFAULT_INTERVAL,
 } from './SmartTransactionsController';
@@ -24,7 +25,7 @@ jest.mock('@ethersproject/bytes', () => ({
 }));
 
 jest.mock('@ethersproject/providers', () => ({
-  Web3Provider: class Web3Provider {
+  Web3Provider: class FakeProvider {
     getBalance = () => ({ toHexString: () => '0x1000' });
 
     getTransactionReceipt = jest.fn(() => ({ blockNumber: '123' }));
@@ -597,10 +598,9 @@ describe('SmartTransactionsController', () => {
         .get(`/networks/${ethereumChainIdDec}/batchStatus?uuids=uuid1`)
         .reply(200, pendingBatchStatusApiResponse);
 
-      await smartTransactionsController.fetchSmartTransactionsStatus(
-        uuids,
-        CHAIN_IDS.ETHEREUM,
-      );
+      await smartTransactionsController.fetchSmartTransactionsStatus(uuids, {
+        networkClientId: 'mainnet',
+      });
       const pendingState = createStateAfterPending()[0];
       const pendingTransaction = { ...pendingState, history: [pendingState] };
       expect(smartTransactionsController.state).toStrictEqual({
@@ -650,10 +650,9 @@ describe('SmartTransactionsController', () => {
         .get(`/networks/${ethereumChainIdDec}/batchStatus?uuids=uuid2`)
         .reply(200, successBatchStatusApiResponse);
 
-      await smartTransactionsController.fetchSmartTransactionsStatus(
-        uuids,
-        CHAIN_IDS.ETHEREUM,
-      );
+      await smartTransactionsController.fetchSmartTransactionsStatus(uuids, {
+        networkClientId: 'mainnet',
+      });
       const successState = createStateAfterSuccess()[0];
       const successTransaction = { ...successState, history: [successState] };
       expect(smartTransactionsController.state).toStrictEqual({
@@ -750,7 +749,10 @@ describe('SmartTransactionsController', () => {
       };
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
-        CHAIN_IDS.ETHEREUM,
+        {
+          chainId: CHAIN_IDS.ETHEREUM,
+          ethersProvider: new Web3Provider(jest.fn()),
+        },
       );
 
       expect(
@@ -783,7 +785,10 @@ describe('SmartTransactionsController', () => {
       };
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
-        CHAIN_IDS.ETHEREUM,
+        {
+          chainId: CHAIN_IDS.ETHEREUM,
+          ethersProvider: new Web3Provider(jest.fn()),
+        },
       );
       expect(confirmSpy).toHaveBeenCalled();
     });
@@ -802,7 +807,10 @@ describe('SmartTransactionsController', () => {
       };
       await smartTransactionsController.confirmSmartTransaction(
         successfulStx as SmartTransaction,
-        CHAIN_IDS.ETHEREUM,
+        {
+          chainId: CHAIN_IDS.ETHEREUM,
+          ethersProvider: new Web3Provider(jest.fn()),
+        },
       );
       expect(confirmExternalMock).toHaveBeenCalled();
     });
@@ -817,7 +825,10 @@ describe('SmartTransactionsController', () => {
       };
       await smartTransactionsController.confirmSmartTransaction(
         successfulStx as SmartTransaction,
-        CHAIN_IDS.ETHEREUM,
+        {
+          chainId: CHAIN_IDS.ETHEREUM,
+          ethersProvider: new Web3Provider(jest.fn()),
+        },
       );
       expect(trackMetaMetricsEventSpy).toHaveBeenCalled();
     });

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -24,25 +24,26 @@ jest.mock('@ethersproject/bytes', () => ({
 }));
 
 jest.mock('@metamask/eth-query', () => {
-  return class FakeEthQuery {
+  const EthQuery = jest.requireActual('@metamask/eth-query');
+  return class FakeEthQuery extends EthQuery {
     sendAsync = jest.fn(({ method }, callback) => {
       switch (method) {
-        case 'getBalance': {
+        case 'eth_getBalance': {
           callback(null, '0x1000');
           break;
         }
 
-        case 'getTransactionReceipt': {
+        case 'eth_getTransactionReceipt': {
           callback(null, { blockNumber: '123' });
           break;
         }
 
-        case 'getBlockByNumber': {
+        case 'eth_getBlockByNumber': {
           callback(null, { baseFeePerGas: '0x123' });
           break;
         }
 
-        case 'getTransactionByHash': {
+        case 'eth_getTransactionByHash': {
           callback(null, {
             maxFeePerGas: '0x123',
             maxPriorityFeePerGas: '0x123',

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -42,7 +42,7 @@ jest.mock('@metamask/eth-query', () => {
           break;
         }
 
-        case 'getTransaction': {
+        case 'getTransactionByHash': {
           callback(null, {
             maxFeePerGas: '0x123',
             maxPriorityFeePerGas: '0x123',

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -322,8 +322,8 @@ export default class SmartTransactionsController extends PollingControllerV1<
         cancelledNonceIndex > -1
           ? currentSmartTransactions
               .slice(0, cancelledNonceIndex)
-              ?.concat(currentSmartTransactions.slice(cancelledNonceIndex + 1))
-              ?.concat(historifiedSmartTransaction)
+              .concat(currentSmartTransactions.slice(cancelledNonceIndex + 1))
+              .concat(historifiedSmartTransaction)
           : currentSmartTransactions?.concat(historifiedSmartTransaction);
       this.update({
         smartTransactionsState: {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -658,7 +658,6 @@ export default class SmartTransactionsController extends PollingControllerV1<
       const preTxBalanceBN = await query(ethQuery, 'getBalance', [
         txParams?.from,
       ]);
-      console.log('preTxBalanceBN', preTxBalanceBN);
       preTxBalance = new BigNumber(preTxBalanceBN.toHexString()).toString(16);
     } catch (e) {
       console.error('ethers error', e);

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -290,6 +290,23 @@ export default class SmartTransactionsController extends PollingControllerV1<
   }
 
   updateSmartTransaction(
+    SmartTransaction: SmartTransaction,
+    { networkClientId }: { networkClientId?: NetworkClientId } = {},
+  ) {
+    let chainId = this.config.chainId;
+    let ethersProvider = this.ethersProvider;
+    if (networkClientId) {
+      const networkClient = this.getNetworkClientById(networkClientId);
+      chainId = networkClient.configuration.chainId;
+      ethersProvider = networkClient.provider;
+    }
+    this.#updateSmartTransaction(SmartTransaction, {
+      chainId,
+      ethersProvider,
+    });
+  }
+
+  #updateSmartTransaction(
     smartTransaction: SmartTransaction,
     {
       chainId = this.config.chainId,
@@ -467,7 +484,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
           category: 'swaps',
         });
 
-        this.updateSmartTransaction(
+        this.#updateSmartTransaction(
           {
             ...smartTransaction,
             confirmed: true,
@@ -501,7 +518,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
 
     const data = await this.fetch(url);
     Object.entries(data).forEach(([uuid, stxStatus]) => {
-      this.updateSmartTransaction(
+      this.#updateSmartTransaction(
         {
           statusMetadata: stxStatus as SmartTransactionsStatus,
           status: calculateStatus(stxStatus as SmartTransactionsStatus),
@@ -653,7 +670,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
       }
       const { nonceDetails } = nonceLock;
 
-      this.updateSmartTransaction(
+      this.#updateSmartTransaction(
         {
           nonceDetails,
           preTxBalance,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -148,7 +148,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
         },
       },
     };
-
+    this.setIntervalLength(this.config.interval || DEFAULT_INTERVAL);
     this.getNonceLock = getNonceLock;
     this.ethersProvider = new Web3Provider(provider);
     this.confirmExternalTransaction = confirmExternalTransaction;
@@ -169,7 +169,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
     this.subscribe((currentState: any) => this.checkPoll(currentState));
   }
 
-  executePoll(networkClientId: string): Promise<void> {
+  _executePoll(networkClientId: string): Promise<void> {
     // if this is going to be truly UI driven polling we shouldn't really reach here
     // with a networkClientId that is not supported, but for now I'll add a check in case
     // wondering if we should add some kind of predicate to the polling controller to check whether
@@ -178,7 +178,6 @@ export default class SmartTransactionsController extends PollingControllerV1<
     if (!this.config.supportedChainIds.includes(chainId)) {
       return Promise.resolve();
     }
-
     return this.updateSmartTransactions(networkClientId);
   }
 
@@ -375,7 +374,6 @@ export default class SmartTransactionsController extends PollingControllerV1<
     const { smartTransactions } = this.state.smartTransactionsState;
 
     const currentSmartTransactions = smartTransactions?.[chainId];
-
     const transactionsToUpdate: string[] = currentSmartTransactions
       .filter(isSmartTransactionPending)
       .map((smartTransaction) => smartTransaction.uuid);
@@ -465,14 +463,12 @@ export default class SmartTransactionsController extends PollingControllerV1<
     const params = new URLSearchParams({
       uuids: uuids.join(','),
     });
-
     const url = `${getAPIRequestURL(
       APIType.BATCH_STATUS,
       chainId,
     )}?${params.toString()}`;
 
     const data = await this.fetch(url);
-
     Object.entries(data).forEach(([uuid, stxStatus]) => {
       this.updateSmartTransaction({
         chainId,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -325,6 +325,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
     const isNewSmartTransaction = this.isNewSmartTransaction(
       smartTransaction.uuid,
     );
+
     this.trackStxStatusChange(
       smartTransaction,
       isNewSmartTransaction
@@ -372,7 +373,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
         ...currentSmartTransaction,
         ...smartTransaction,
       };
-      this.confirmSmartTransaction(nextSmartTransaction, {
+      this.#confirmSmartTransaction(nextSmartTransaction, {
         chainId,
         ethQuery,
       });
@@ -416,7 +417,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
   }
 
   // TODO make this a private method?
-  async confirmSmartTransaction(
+  async #confirmSmartTransaction(
     smartTransaction: SmartTransaction,
     {
       chainId,
@@ -566,7 +567,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
   async getFees(
     tradeTx: UnsignedTransaction,
     approvalTx: UnsignedTransaction,
-    networkClientId?: NetworkClientId,
+    { networkClientId }: { networkClientId?: NetworkClientId } = {},
   ): Promise<Fees> {
     const chainId = this.getChainId({ networkClientId });
     const transactions = [];
@@ -657,7 +658,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
       ]);
       preTxBalance = new BigNumber(preTxBalanceBN).toString(16);
     } catch (e) {
-      console.error('ethers error', e);
+      console.error('provider error', e);
     }
     const nonceLock = await this.getNonceLock(txParams?.from);
     try {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -416,7 +416,6 @@ export default class SmartTransactionsController extends PollingControllerV1<
     }
   }
 
-  // TODO make this a private method?
   async #confirmSmartTransaction(
     smartTransaction: SmartTransaction,
     {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -349,7 +349,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
         ...currentSmartTransaction,
         ...smartTransaction,
       };
-      this.#confirmSmartTransaction(nextSmartTransaction, currentChainId);
+      this.confirmSmartTransaction(nextSmartTransaction, currentChainId);
     }
 
     this.update({
@@ -385,7 +385,8 @@ export default class SmartTransactionsController extends PollingControllerV1<
     }
   }
 
-  async #confirmSmartTransaction(
+  // TODO make this a private method?
+  async confirmSmartTransaction(
     smartTransaction: SmartTransaction,
     chainId: string,
   ) {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -290,17 +290,18 @@ export default class SmartTransactionsController extends PollingControllerV1<
   }
 
   updateSmartTransaction(
-    SmartTransaction: SmartTransaction,
+    smartTransaction: SmartTransaction,
     { networkClientId }: { networkClientId?: NetworkClientId } = {},
   ) {
-    let chainId = this.config.chainId;
-    let ethersProvider = this.ethersProvider;
+    let { chainId } = this.config;
+    let { ethersProvider } = this;
     if (networkClientId) {
       const networkClient = this.getNetworkClientById(networkClientId);
       chainId = networkClient.configuration.chainId;
       ethersProvider = networkClient.provider;
     }
-    this.#updateSmartTransaction(SmartTransaction, {
+
+    this.#updateSmartTransaction(smartTransaction, {
       chainId,
       ethersProvider,
     });

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -310,7 +310,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
 
     if (isNewSmartTransaction) {
       // add smart transaction
-      const cancelledNonceIndex = currentSmartTransactions.findIndex(
+      const cancelledNonceIndex = currentSmartTransactions?.findIndex(
         (stx: SmartTransaction) =>
           stx.txParams?.nonce === smartTransaction.txParams?.nonce &&
           stx.status?.startsWith('cancelled'),
@@ -322,9 +322,9 @@ export default class SmartTransactionsController extends PollingControllerV1<
         cancelledNonceIndex > -1
           ? currentSmartTransactions
               .slice(0, cancelledNonceIndex)
-              .concat(currentSmartTransactions.slice(cancelledNonceIndex + 1))
-              .concat(historifiedSmartTransaction)
-          : currentSmartTransactions.concat(historifiedSmartTransaction);
+              ?.concat(currentSmartTransactions.slice(cancelledNonceIndex + 1))
+              ?.concat(historifiedSmartTransaction)
+          : currentSmartTransactions?.concat(historifiedSmartTransaction);
       this.update({
         smartTransactionsState: {
           ...smartTransactionsState,

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -60,7 +60,7 @@ export type SmartTransactionsControllerState = BaseState & {
     liveness: boolean | undefined;
     fees: FeeEstimates;
     feesByChainId: Record<Hex, FeeEstimates>;
-    livenessByChainId: Record<Hex, boolean | undefined>;
+    livenessByChainId: Record<Hex, boolean>;
   };
 };
 
@@ -606,23 +606,15 @@ export default class SmartTransactionsController extends PollingControllerV1<
           approvalTxFees,
           tradeTxFees,
         },
-      },
-    });
-
-    if (networkClientId) {
-      this.update({
-        smartTransactionsState: {
-          ...this.state.smartTransactionsState,
-          feesByChainId: {
-            ...this.state.smartTransactionsState.feesByChainId,
-            [chainId]: {
-              approvalTxFees,
-              tradeTxFees,
-            },
+        feesByChainId: {
+          ...this.state.smartTransactionsState.feesByChainId,
+          [chainId]: {
+            approvalTxFees,
+            tradeTxFees,
           },
         },
-      });
-    }
+      },
+    });
 
     return {
       approvalTxFees,
@@ -709,7 +701,11 @@ export default class SmartTransactionsController extends PollingControllerV1<
   // in transaction controller external transactions list
   async cancelSmartTransaction(
     uuid: string,
-    networkClientId?: NetworkClientId,
+    {
+      networkClientId,
+    }: {
+      networkClientId?: NetworkClientId;
+    } = {},
   ): Promise<void> {
     const chainId = this.getChainId(networkClientId);
     await this.fetch(getAPIRequestURL(APIType.CANCEL, chainId), {
@@ -734,20 +730,12 @@ export default class SmartTransactionsController extends PollingControllerV1<
       smartTransactionsState: {
         ...this.state.smartTransactionsState,
         liveness,
+        livenessByChainId: {
+          ...this.state.smartTransactionsState.livenessByChainId,
+          [chainId]: liveness,
+        },
       },
     });
-
-    if (networkClientId) {
-      this.update({
-        smartTransactionsState: {
-          ...this.state.smartTransactionsState,
-          livenessByChainId: {
-            ...this.state.smartTransactionsState.livenessByChainId,
-            [chainId]: liveness,
-          },
-        },
-      });
-    }
 
     return liveness;
   }

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -292,10 +292,9 @@ export default class SmartTransactionsController extends PollingControllerV1<
     smartTransaction: SmartTransaction,
     chainId: string,
   ): void {
-    const currentChainId = chainId || this.config.chainId;
     const { smartTransactionsState } = this.state;
     const { smartTransactions } = smartTransactionsState;
-    const currentSmartTransactions = smartTransactions[currentChainId];
+    const currentSmartTransactions = smartTransactions[chainId];
     const currentIndex = currentSmartTransactions?.findIndex(
       (stx) => stx.uuid === smartTransaction.uuid,
     );
@@ -331,7 +330,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
           ...smartTransactionsState,
           smartTransactions: {
             ...smartTransactionsState.smartTransactions,
-            [currentChainId]: nextSmartTransactions,
+            [chainId]: nextSmartTransactions,
           },
         },
       });
@@ -349,7 +348,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
         ...currentSmartTransaction,
         ...smartTransaction,
       };
-      this.confirmSmartTransaction(nextSmartTransaction, currentChainId);
+      this.confirmSmartTransaction(nextSmartTransaction, chainId);
     }
 
     this.update({
@@ -357,13 +356,13 @@ export default class SmartTransactionsController extends PollingControllerV1<
         ...smartTransactionsState,
         smartTransactions: {
           ...smartTransactionsState.smartTransactions,
-          [currentChainId]: smartTransactionsState.smartTransactions[
-            currentChainId
-          ].map((item, index) => {
-            return index === currentIndex
-              ? { ...item, ...smartTransaction }
-              : item;
-          }),
+          [chainId]: smartTransactionsState.smartTransactions[chainId].map(
+            (item, index) => {
+              return index === currentIndex
+                ? { ...item, ...smartTransaction }
+                : item;
+            },
+          ),
         },
       },
     });

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -437,7 +437,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
       const transaction: {
         maxFeePerGas?: string;
         maxPriorityFeePerGas?: string;
-      } = await query(ethQuery, 'getTransaction', [txHash]);
+      } | null = await query(ethQuery, 'getTransactionByHash', [txHash]);
 
       const maxFeePerGas = transaction?.maxFeePerGas;
       const maxPriorityFeePerGas = transaction?.maxPriorityFeePerGas;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const API_BASE_URL = 'https://transaction.metaswap.codefi.network';
 export const CHAIN_IDS = {
   ETHEREUM: '0x1',
+  GOERLI: '0x5',
   RINKEBY: '0x4',
   BSC: '0x38',
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,12 @@
+import { Hex } from './types';
+
 export const API_BASE_URL = 'https://transaction.metaswap.codefi.network';
-export const CHAIN_IDS = {
+export const CHAIN_IDS: {
+  ETHEREUM: Hex;
+  GOERLI: Hex;
+  RINKEBY: Hex;
+  BSC: Hex;
+} = {
   ETHEREUM: '0x1',
   GOERLI: '0x5',
   RINKEBY: '0x4',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,7 @@
-import { Hex } from './types';
-
 export const API_BASE_URL = 'https://transaction.metaswap.codefi.network';
-export const CHAIN_IDS: {
-  ETHEREUM: Hex;
-  GOERLI: Hex;
-  RINKEBY: Hex;
-  BSC: Hex;
-} = {
+export const CHAIN_IDS = {
   ETHEREUM: '0x1',
   GOERLI: '0x5',
   RINKEBY: '0x4',
   BSC: '0x38',
-};
+} as const;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ describe('default export', () => {
       provider: jest.fn(),
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
+      getNetworkClientById: jest.fn(),
     });
     expect(controller).toBeInstanceOf(SmartTransactionsController);
     jest.clearAllTimers();

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,3 +117,5 @@ export type SignedTransaction = any;
 
 // TODO
 export type SignedCanceledTransaction = any;
+
+export type Hex = `0x${string}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,66 +528,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abstract-provider@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-provider@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-  checksum: 74cf4696245cf03bb7cc5b6cbf7b4b89dd9a79a1c4688126d214153a938126d4972d42c93182198653ce1de35f2a2cad68be40337d4774b3698a39b28f0228a8
-  languageName: node
-  linkType: hard
-
-"@ethersproject/abstract-signer@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-signer@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: a823dac9cfb761e009851050ebebd5b229d1b1cc4a75b125c2da130ff37e8218208f7f9d1386f77407705b889b23d4a230ad67185f8872f083143e0073cbfbe3
-  languageName: node
-  linkType: hard
-
-"@ethersproject/address@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/address@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-  checksum: 64ea5ebea9cc0e845c413e6cb1e54e157dd9fc0dffb98e239d3a3efc8177f2ff798cd4e3206cf3660ee8faeb7bef1a47dc0ebef0d7b132c32e61e550c7d4c843
-  languageName: node
-  linkType: hard
-
-"@ethersproject/base64@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/base64@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-  checksum: 7dd5d734d623582f08f665434f53685041a3d3b334a0e96c0c8afa8bbcaab934d50e5b6b980e826a8fde8d353e0b18f11e61faf17468177274b8e7c69cd9742b
-  languageName: node
-  linkType: hard
-
-"@ethersproject/basex@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/basex@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: 326087b7e1f3787b5fe6cd1cf2b4b5abfafbc355a45e88e22e5e9d6c845b613ffc5301d629b28d5c4d5e2bfe9ec424e6782c804956dff79be05f0098cb5817de
-  languageName: node
-  linkType: hard
-
 "@ethersproject/bignumber@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/bignumber@npm:5.7.0"
@@ -608,178 +548,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/constants@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/constants@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-  checksum: 6d4b1355747cce837b3e76ec3bde70e4732736f23b04f196f706ebfa5d4d9c2be50904a390d4d40ce77803b98d03d16a9b6898418e04ba63491933ce08c4ba8a
-  languageName: node
-  linkType: hard
-
-"@ethersproject/hash@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/hash@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 6e9fa8d14eb08171cd32f17f98cc108ec2aeca74a427655f0d689c550fee0b22a83b3b400fad7fb3f41cf14d4111f87f170aa7905bcbcd1173a55f21b06262ef
-  languageName: node
-  linkType: hard
-
-"@ethersproject/keccak256@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/keccak256@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    js-sha3: 0.8.0
-  checksum: ff70950d82203aab29ccda2553422cbac2e7a0c15c986bd20a69b13606ed8bb6e4fdd7b67b8d3b27d4f841e8222cbaccd33ed34be29f866fec7308f96ed244c6
-  languageName: node
-  linkType: hard
-
 "@ethersproject/logger@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/logger@npm:5.7.0"
   checksum: 075ab2f605f1fd0813f2e39c3308f77b44a67732b36e712d9bc085f22a84aac4da4f71b39bee50fe78da3e1c812673fadc41180c9970fe5e486e91ea17befe0d
-  languageName: node
-  linkType: hard
-
-"@ethersproject/networks@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/networks@npm:5.7.0"
-  dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 4f4d77e7c59e79cfcba616315a5d0e634a7653acbd11bb06a0028f4bd009b19f9a31556148a1e38f7308f55d1a1d170eb9f065290de9f9cf104b34e91cc348b8
-  languageName: node
-  linkType: hard
-
-"@ethersproject/properties@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/properties@npm:5.7.0"
-  dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 6ab0ccf0c3aadc9221e0cdc5306ce6cd0df7f89f77d77bccdd1277182c9ead0202cd7521329ba3acde130820bf8af299e17cf567d0d497c736ee918207bbf59f
-  languageName: node
-  linkType: hard
-
-"@ethersproject/providers@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/providers@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-    bech32: 1.1.4
-    ws: 7.4.6
-  checksum: a6f80cea838424ceb367ff8e0f004f9fd6b43a87505da9d6aef33eb2bbc77cdb03ab51709ae83b7aa07d038fadf00634e08d8683fe6ae8b17b9351e3b30b26cb
-  languageName: node
-  linkType: hard
-
-"@ethersproject/random@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/random@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 017829c91cff6c76470852855108115b0b52c611b6be817ed1948d56ba42d6677803ec2012aa5ae298a7660024156a64c11fcf544e235e239ab3f89f0fff7345
-  languageName: node
-  linkType: hard
-
-"@ethersproject/rlp@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/rlp@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: bce165b0f7e68e4d091c9d3cf47b247cac33252df77a095ca4281d32d5eeaaa3695d9bc06b2b057c5015353a68df89f13a4a54a72e888e4beeabbe56b15dda6e
-  languageName: node
-  linkType: hard
-
-"@ethersproject/sha2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/sha2@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    hash.js: 1.1.7
-  checksum: 09321057c022effbff4cc2d9b9558228690b5dd916329d75c4b1ffe32ba3d24b480a367a7cc92d0f0c0b1c896814d03351ae4630e2f1f7160be2bcfbde435dbc
-  languageName: node
-  linkType: hard
-
-"@ethersproject/signing-key@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/signing-key@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    bn.js: ^5.2.1
-    elliptic: 6.5.4
-    hash.js: 1.1.7
-  checksum: 8f8de09b0aac709683bbb49339bc0a4cd2f95598f3546436c65d6f3c3a847ffa98e06d35e9ed2b17d8030bd2f02db9b7bd2e11c5cf8a71aad4537487ab4cf03a
-  languageName: node
-  linkType: hard
-
-"@ethersproject/strings@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/strings@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 5ff78693ae3fdf3cf23e1f6dc047a61e44c8197d2408c42719fef8cb7b7b3613a4eec88ac0ed1f9f5558c74fe0de7ae3195a29ca91a239c74b9f444d8e8b50df
-  languageName: node
-  linkType: hard
-
-"@ethersproject/transactions@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/transactions@npm:5.7.0"
-  dependencies:
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-  checksum: a31b71996d2b283f68486241bff0d3ea3f1ba0e8f1322a8fffc239ccc4f4a7eb2ea9994b8fd2f093283fd75f87bae68171e01b6265261f821369aca319884a79
-  languageName: node
-  linkType: hard
-
-"@ethersproject/web@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/web@npm:5.7.0"
-  dependencies:
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 9d4ca82f8b1295bbc1c59d58cb351641802d2f70f4b7d523fc726f51b0615296da6d6585dee5749b4d5e4a6a9af6d6650d46fe562d5b04f43a0af5c7f7f4a77e
   languageName: node
   linkType: hard
 
@@ -1343,7 +1115,6 @@ __metadata:
   dependencies:
     "@ethersproject/bignumber": ^5.7.0
     "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/providers": ^5.7.0
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
@@ -1352,6 +1123,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
+    "@metamask/eth-query": ^3.0.1
     "@metamask/network-controller": ^15.0.0
     "@metamask/polling-controller": ^0.2.0
     "@types/jest": ^26.0.24
@@ -2380,13 +2152,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bech32@npm:1.1.4":
-  version: 1.1.4
-  resolution: "bech32@npm:1.1.4"
-  checksum: 0e98db619191548390d6f09ff68b0253ba7ae6a55db93dfdbb070ba234c1fd3308c0606fbcc95fad50437227b10011e2698b89f0181f6e7f845c499bd14d0f4b
-  languageName: node
-  linkType: hard
-
 "big-integer@npm:^1.6.44":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
@@ -3272,7 +3037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.5.2":
+"elliptic@npm:^6.5.2":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -4632,7 +4397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -5811,13 +5576,6 @@ __metadata:
   version: 4.4.0
   resolution: "js-sdsl@npm:4.4.0"
   checksum: 7bb08a2d746ab7ff742720339aa006c631afe05e77d11eda988c1c35fae8e03e492e4e347e883e786e3ce6170685d4780c125619111f0730c11fdb41b04059c7
-  languageName: node
-  linkType: hard
-
-"js-sha3@npm:0.8.0":
-  version: 0.8.0
-  resolution: "js-sha3@npm:0.8.0"
-  checksum: 75df77c1fc266973f06cce8309ce010e9e9f07ec35ab12022ed29b7f0d9c8757f5a73e1b35aa24840dced0dea7059085aa143d817aea9e188e2a80d569d9adce
   languageName: node
   linkType: hard
 
@@ -8924,7 +8682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.6, ws@npm:^7.4.4":
+"ws@npm:^7.4.4":
   version: 7.4.6
   resolution: "ws@npm:7.4.6"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,6 +1336,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
     "@metamask/network-controller": ^15.0.0
+    "@metamask/polling-controller": ^0.1.0
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^16.18.31
@@ -1752,6 +1753,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^8.3.0":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,17 +528,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/bignumber@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/bignumber@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    bn.js: ^5.2.1
-  checksum: 8c9a134b76f3feb4ec26a5a27379efb4e156b8fb2de0678a67788a91c7f4e30abe9d948638458e4b20f2e42380da0adacc7c9389d05fce070692edc6ae9b4904
-  languageName: node
-  linkType: hard
-
 "@ethersproject/bytes@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/bytes@npm:5.7.0"
@@ -1113,7 +1102,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/smart-transactions-controller@workspace:."
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
     "@ethersproject/bytes": ^5.7.0
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
@@ -2199,7 +2187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.1.2, bn.js@npm:^5.2.1":
+"bn.js@npm:^5.1.2":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,6 +1303,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/polling-controller@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/polling-controller@npm:0.2.0"
+  dependencies:
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/controller-utils": ^5.0.2
+    "@metamask/network-controller": ^15.0.0
+    "@metamask/utils": ^8.1.0
+    "@types/uuid": ^8.3.0
+    fast-json-stable-stringify: ^2.1.0
+    uuid: ^8.3.2
+  peerDependencies:
+    "@metamask/network-controller": ^15.0.0
+  checksum: 4dee3e49b23ba2b92055816dcc68b8e468405d9b00528d14b01c490058dea6e7aae943b19a007adbbbe06aa9a5b61d961211f9de82c8b55c7622599de78eb76e
+  languageName: node
+  linkType: hard
+
 "@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/rpc-errors@npm:6.1.0"
@@ -1336,7 +1353,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
     "@metamask/network-controller": ^15.0.0
-    "@metamask/polling-controller": ^0.1.0
+    "@metamask/polling-controller": ^0.2.0
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^16.18.31
@@ -4035,7 +4052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb


### PR DESCRIPTION
Resolves: https://github.com/MetaMask/MetaMask-planning/issues/1039

Integrates new `PollingController` abstraction into the `SmartTransactionsController`, implements the `_executePoll` method and parameterizes the `updateSmartTransactions` method by networkClientId such that pending SmartTransaction statuses can be polled for concurrently across different chains.

A note: As is our current controller refactor strategy, these changes are additive, backwards compatible and coexist alongside the existing globally selected network pattern. Once we fully adopt this polling pattern we should no longer access the root `liveness` and `fees` state but rather access these values by chainId from `livenessByChainId` and `feesByChainId`.

### Added
- Integrates `PollingController` mixin into the `SmartTransactionsController` and implements the abstract `_executePoll` method.
### Changed
- Adds optional options object containing a `networkClientId` argument to the `updateSmartTransaction` method which, if passed, is used fetch the chainId that corresponds to the `networkClientId` and is then used to fetch and update the status of pending smart transactions for that chainId.