### PR TITLE
Parameterize SmartTransactionsController state by ChainId for MultiChain + Integrate PollingController Mixin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 77,
-      functions: 89,
-      lines: 92,
-      statements: 91,
+      branches: 76.5,
+      functions: 92.5,
+      lines: 93.35,
+      statements: 93.35,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
-    "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
-    "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^6.0.0",
     "@metamask/network-controller": "^17.0.0",
+    "@metamask/eth-query": "^3.0.1",
+    "@metamask/polling-controller": "^1.0.1",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"
@@ -45,6 +45,7 @@
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.194",
     "@types/node": "^16.18.31",
+    "@types/sinon": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "eslint": "^8.21.0",
@@ -59,6 +60,7 @@
     "nock": "^13.3.1",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.4.3",
+    "sinon": "^9.2.4",
     "ts-jest": "^26.5.6",
     "typescript": "~4.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
-    "@metamask/network-controller": "^17.0.0",
     "@metamask/base-controller": "^4.0.0",
     "@metamask/controller-utils": "^6.1.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/polling-controller": "^1.0.1",
+    "@metamask/network-controller": "^17.0.0",
+    "@metamask/polling-controller": "^2.0.0",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
-    "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^6.0.0",
     "@metamask/network-controller": "^17.0.0",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/base-controller": "^4.0.0",
+    "@metamask/controller-utils": "^6.1.0",
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/polling-controller": "^1.0.1",
     "bignumber.js": "^9.0.1",
     "fast-json-patch": "^3.1.0",

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -938,57 +938,50 @@ describe('SmartTransactionsController', () => {
 
       await advanceTime({ clock, duration: 0 });
 
-      expect(
-        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
-      ).toStrictEqual(
-        JSON.stringify([
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.ETHEREUM,
-          )}/batchStatus?uuids=uuid1`,
-        ]),
+      const fetchHeaders = {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Client-Id': 'default',
+        },
+      };
+
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        1,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.ETHEREUM,
+        )}/batchStatus?uuids=uuid1`,
+        fetchHeaders,
       );
 
-      handleFetchSpy.mockClear();
       await advanceTime({ clock, duration: DEFAULT_INTERVAL });
 
-      expect(
-        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
-      ).toStrictEqual(
-        JSON.stringify([
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.ETHEREUM,
-          )}/batchStatus?uuids=uuid1`,
-        ]),
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        2,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.ETHEREUM,
+        )}/batchStatus?uuids=uuid1`,
+        fetchHeaders,
       );
 
-      handleFetchSpy.mockClear();
       smartTransactionsController.startPollingByNetworkClientId('goerli');
       await advanceTime({ clock, duration: 0 });
 
-      expect(
-        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
-      ).toStrictEqual(
-        JSON.stringify([
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.GOERLI,
-          )}/batchStatus?uuids=uuid2`,
-        ]),
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        3,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.GOERLI,
+        )}/batchStatus?uuids=uuid2`,
+        fetchHeaders,
       );
 
-      handleFetchSpy.mockClear();
       await advanceTime({ clock, duration: DEFAULT_INTERVAL });
 
-      expect(
-        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
-      ).toStrictEqual(
-        JSON.stringify([
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.ETHEREUM,
-          )}/batchStatus?uuids=uuid1`,
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.GOERLI,
-          )}/batchStatus?uuids=uuid2`,
-        ]),
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        5,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.GOERLI,
+        )}/batchStatus?uuids=uuid2`,
+        fetchHeaders,
       );
 
       // stop the mainnet polling
@@ -997,23 +990,25 @@ describe('SmartTransactionsController', () => {
       );
 
       // cycle two polling intervals
-      handleFetchSpy.mockClear();
       await advanceTime({ clock, duration: DEFAULT_INTERVAL });
 
       await advanceTime({ clock, duration: DEFAULT_INTERVAL });
 
       // check that the mainnet polling has stopped while the goerli polling continues
-      expect(
-        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
-      ).toStrictEqual(
-        JSON.stringify([
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.GOERLI,
-          )}/batchStatus?uuids=uuid2`,
-          `${API_BASE_URL}/networks/${convertHexToDecimal(
-            CHAIN_IDS.GOERLI,
-          )}/batchStatus?uuids=uuid2`,
-        ]),
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        6,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.GOERLI,
+        )}/batchStatus?uuids=uuid2`,
+        fetchHeaders,
+      );
+
+      expect(handleFetchSpy).toHaveBeenNthCalledWith(
+        7,
+        `${API_BASE_URL}/networks/${convertHexToDecimal(
+          CHAIN_IDS.GOERLI,
+        )}/batchStatus?uuids=uuid2`,
+        fetchHeaders,
       );
 
       // cleanup

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -323,7 +323,7 @@ describe('SmartTransactionsController', () => {
           releaseLock: jest.fn(),
         };
       }),
-      provider: jest.fn(),
+      provider: { sendAsync: jest.fn() },
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: trackMetaMetricsEventSpy,
       getNetworkClientById: jest.fn().mockImplementation((networkClientId) => {

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -14,8 +14,6 @@ import { SmartTransaction, SmartTransactionStatuses } from './types';
 import * as utils from './utils';
 import { flushPromises, advanceTime } from './test-helpers';
 
-// const confirmExternalMock = jest.fn();
-
 jest.mock('@ethersproject/bytes', () => ({
   ...jest.requireActual('@ethersproject/bytes'),
   hexlify: (str: string) => `0x${str}`,

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1,5 +1,7 @@
 import nock from 'nock';
+import * as sinon from 'sinon';
 import { NetworkState } from '@metamask/network-controller';
+import { convertHexToDecimal } from '@metamask/controller-utils';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import packageJson from '../package.json';
@@ -9,32 +11,55 @@ import SmartTransactionsController, {
 } from './SmartTransactionsController';
 import { API_BASE_URL, CHAIN_IDS } from './constants';
 import { SmartTransaction, SmartTransactionStatuses } from './types';
+import * as utils from './utils';
+import { flushPromises, advanceTime } from './test-helpers';
 
-const confirmExternalMock = jest.fn();
+// const confirmExternalMock = jest.fn();
 
 jest.mock('@ethersproject/bytes', () => ({
   ...jest.requireActual('@ethersproject/bytes'),
   hexlify: (str: string) => `0x${str}`,
 }));
 
-jest.mock('@ethersproject/providers', () => ({
-  Web3Provider: class Web3Provider {
-    getBalance = () => ({ toHexString: () => '0x1000' });
+jest.mock('@metamask/eth-query', () => {
+  const EthQuery = jest.requireActual('@metamask/eth-query');
+  return class FakeEthQuery extends EthQuery {
+    sendAsync = jest.fn(({ method }, callback) => {
+      switch (method) {
+        case 'eth_getBalance': {
+          callback(null, '0x1000');
+          break;
+        }
 
-    getTransactionReceipt = jest.fn(() => ({ blockNumber: '123' }));
+        case 'eth_getTransactionReceipt': {
+          callback(null, { blockNumber: '123' });
+          break;
+        }
 
-    getTransaction = jest.fn(() => ({
-      maxFeePerGas: { toHexString: () => '0x123' },
-      maxPriorityFeePerGas: { toHexString: () => '0x123' },
-    }));
+        case 'eth_getBlockByNumber': {
+          callback(null, { baseFeePerGas: '0x123' });
+          break;
+        }
 
-    getBlock = jest.fn();
-  },
-}));
+        case 'eth_getTransactionByHash': {
+          callback(null, {
+            maxFeePerGas: '0x123',
+            maxPriorityFeePerGas: '0x123',
+          });
+          break;
+        }
+
+        default: {
+          throw new Error('Invalid method');
+        }
+      }
+    });
+  };
+});
 
 const addressFrom = '0x268392a24B6b093127E8581eAfbD1DA228bAdAe3';
 
-const createUnsignedTransaction = () => {
+const createUnsignedTransaction = (chainId: number) => {
   return {
     from: addressFrom,
     to: '0x0000000000000000000000000000000000000000',
@@ -42,7 +67,7 @@ const createUnsignedTransaction = () => {
     data: '0x',
     nonce: 0,
     type: 2,
-    chainId: 4,
+    chainId,
   };
 };
 
@@ -252,13 +277,41 @@ const testHistory = [
 ];
 
 const ethereumChainIdDec = parseInt(CHAIN_IDS.ETHEREUM, 16);
+const goerliChainIdDec = parseInt(CHAIN_IDS.GOERLI, 16);
 
 const trackMetaMetricsEventSpy = jest.fn();
+const defaultState = {
+  smartTransactionsState: {
+    smartTransactions: {
+      [CHAIN_IDS.ETHEREUM]: [],
+    },
+    userOptIn: undefined,
+    userOptInV2: undefined,
+    fees: {
+      approvalTxFees: undefined,
+      tradeTxFees: undefined,
+    },
+    feesByChainId: {
+      [CHAIN_IDS.ETHEREUM]: {
+        approvalTxFees: undefined,
+        tradeTxFees: undefined,
+      },
+      [CHAIN_IDS.GOERLI]: {
+        approvalTxFees: undefined,
+        tradeTxFees: undefined,
+      },
+    },
+    liveness: true,
+    livenessByChainId: {
+      [CHAIN_IDS.ETHEREUM]: true,
+      [CHAIN_IDS.GOERLI]: true,
+    },
+  },
+};
 
 describe('SmartTransactionsController', () => {
   let smartTransactionsController: SmartTransactionsController;
   let networkListener: (networkState: NetworkState) => void;
-
   beforeEach(() => {
     smartTransactionsController = new SmartTransactionsController({
       onNetworkStateChange: (listener) => {
@@ -271,8 +324,26 @@ describe('SmartTransactionsController', () => {
         };
       }),
       provider: jest.fn(),
-      confirmExternalTransaction: confirmExternalMock,
+      confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: trackMetaMetricsEventSpy,
+      getNetworkClientById: jest.fn().mockImplementation((networkClientId) => {
+        switch (networkClientId) {
+          case 'mainnet':
+            return {
+              configuration: {
+                chainId: CHAIN_IDS.ETHEREUM,
+              },
+            };
+          case 'goerli':
+            return {
+              configuration: {
+                chainId: CHAIN_IDS.GOERLI,
+              },
+            };
+          default:
+            throw new Error('Invalid network client id');
+        }
+      }),
     });
     // eslint-disable-next-line jest/prefer-spy-on
     smartTransactionsController.subscribe = jest.fn();
@@ -287,38 +358,35 @@ describe('SmartTransactionsController', () => {
   it('initializes with default config', () => {
     expect(smartTransactionsController.config).toStrictEqual({
       interval: DEFAULT_INTERVAL,
-      supportedChainIds: [CHAIN_IDS.ETHEREUM, CHAIN_IDS.RINKEBY],
+      supportedChainIds: [CHAIN_IDS.ETHEREUM, CHAIN_IDS.GOERLI],
       chainId: CHAIN_IDS.ETHEREUM,
       clientId: 'default',
     });
   });
 
   it('initializes with default state', () => {
-    expect(smartTransactionsController.state).toStrictEqual({
-      smartTransactionsState: {
-        smartTransactions: {
-          [CHAIN_IDS.ETHEREUM]: [],
-        },
-        userOptIn: undefined,
-        userOptInV2: undefined,
-        fees: {
-          approvalTxFees: undefined,
-          tradeTxFees: undefined,
-        },
-        liveness: true,
-      },
-    });
+    expect(smartTransactionsController.state).toStrictEqual(defaultState);
   });
 
   describe('onNetworkChange', () => {
     it('is triggered', () => {
-      networkListener({ providerConfig: { chainId: '52' } } as NetworkState);
-      expect(smartTransactionsController.config.chainId).toBe('52');
+      networkListener({
+        providerConfig: { chainId: '0x32', type: 'rpc', ticker: 'CET' },
+        selectedNetworkClientId: 'networkClientId',
+        networkConfigurations: {},
+        networksMetadata: {},
+      } as NetworkState);
+      expect(smartTransactionsController.config.chainId).toBe('0x32');
     });
 
     it('calls poll', () => {
       const checkPollSpy = jest.spyOn(smartTransactionsController, 'checkPoll');
-      networkListener({ providerConfig: { chainId: '2' } } as NetworkState);
+      networkListener({
+        providerConfig: { chainId: '0x32', type: 'rpc', ticker: 'CET' },
+        selectedNetworkClientId: 'networkClientId',
+        networkConfigurations: {},
+        networksMetadata: {},
+      } as NetworkState);
       expect(checkPollSpy).toHaveBeenCalled();
     });
   });
@@ -345,7 +413,7 @@ describe('SmartTransactionsController', () => {
 
     it('calls stop if there is a timeoutHandle and no pending transactions', () => {
       const stopSpy = jest.spyOn(smartTransactionsController, 'stop');
-      smartTransactionsController.timeoutHandle = setInterval(() => ({}));
+      smartTransactionsController.timeoutHandle = setTimeout(() => ({}));
       smartTransactionsController.checkPoll(smartTransactionsController.state);
       expect(stopSpy).toHaveBeenCalled();
       clearInterval(smartTransactionsController.timeoutHandle);
@@ -359,12 +427,19 @@ describe('SmartTransactionsController', () => {
         'updateSmartTransactions',
       );
       expect(updateSmartTransactionsSpy).not.toHaveBeenCalled();
-      networkListener({ providerConfig: { chainId: '56' } } as NetworkState);
+      networkListener({
+        providerConfig: { chainId: '0x32', type: 'rpc', ticker: 'CET' },
+        selectedNetworkClientId: 'networkClientId',
+        networkConfigurations: {},
+        networksMetadata: {},
+      } as NetworkState);
       expect(updateSmartTransactionsSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('updateSmartTransactions', () => {
+    // TODO rewrite this test... updateSmartTransactions is getting called via the checkPoll method which is called whenever state is updated.
+    // this test should be more isolated to the updateSmartTransactions method.
     it('calls fetchSmartTransactionsStatus if there are pending transactions', () => {
       const fetchSmartTransactionsStatusSpy = jest
         .spyOn(smartTransactionsController, 'fetchSmartTransactionsStatus')
@@ -436,8 +511,8 @@ describe('SmartTransactionsController', () => {
 
   describe('getFees', () => {
     it('gets unsigned transactions and estimates based on an unsigned transaction', async () => {
-      const tradeTx = createUnsignedTransaction();
-      const approvalTx = createUnsignedTransaction();
+      const tradeTx = createUnsignedTransaction(ethereumChainIdDec);
+      const approvalTx = createUnsignedTransaction(ethereumChainIdDec);
       const getFeesApiResponse = createGetFeesApiResponse();
       nock(API_BASE_URL)
         .post(`/networks/${ethereumChainIdDec}/getFees`)
@@ -449,6 +524,36 @@ describe('SmartTransactionsController', () => {
       expect(fees).toMatchObject({
         approvalTxFees: getFeesApiResponse.txs[0],
         tradeTxFees: getFeesApiResponse.txs[1],
+      });
+    });
+
+    it('should add fee data to feesByChainId state using the networkClientId passed in to identify the appropriate chain', async () => {
+      const tradeTx = createUnsignedTransaction(goerliChainIdDec);
+      const approvalTx = createUnsignedTransaction(goerliChainIdDec);
+      const getFeesApiResponse = createGetFeesApiResponse();
+      nock(API_BASE_URL)
+        .post(`/networks/${goerliChainIdDec}/getFees`)
+        .reply(200, getFeesApiResponse);
+
+      expect(
+        smartTransactionsController.state.smartTransactionsState.feesByChainId,
+      ).toStrictEqual(defaultState.smartTransactionsState.feesByChainId);
+
+      await smartTransactionsController.getFees(tradeTx, approvalTx, {
+        networkClientId: 'goerli',
+      });
+
+      expect(
+        smartTransactionsController.state.smartTransactionsState.feesByChainId,
+      ).toMatchObject({
+        [CHAIN_IDS.ETHEREUM]: {
+          approvalTxFees: undefined,
+          tradeTxFees: undefined,
+        },
+        [CHAIN_IDS.GOERLI]: {
+          approvalTxFees: getFeesApiResponse.txs[0],
+          tradeTxFees: getFeesApiResponse.txs[1],
+        },
       });
     });
   });
@@ -496,7 +601,10 @@ describe('SmartTransactionsController', () => {
       nock(API_BASE_URL)
         .get(`/networks/${ethereumChainIdDec}/batchStatus?uuids=uuid1`)
         .reply(200, pendingBatchStatusApiResponse);
-      await smartTransactionsController.fetchSmartTransactionsStatus(uuids);
+
+      await smartTransactionsController.fetchSmartTransactionsStatus(uuids, {
+        networkClientId: 'mainnet',
+      });
       const pendingState = createStateAfterPending()[0];
       const pendingTransaction = { ...pendingState, history: [pendingState] };
       expect(smartTransactionsController.state).toStrictEqual({
@@ -510,7 +618,21 @@ describe('SmartTransactionsController', () => {
             approvalTxFees: undefined,
             tradeTxFees: undefined,
           },
+          feesByChainId: {
+            [CHAIN_IDS.ETHEREUM]: {
+              approvalTxFees: undefined,
+              tradeTxFees: undefined,
+            },
+            [CHAIN_IDS.GOERLI]: {
+              approvalTxFees: undefined,
+              tradeTxFees: undefined,
+            },
+          },
           liveness: true,
+          livenessByChainId: {
+            [CHAIN_IDS.ETHEREUM]: true,
+            [CHAIN_IDS.GOERLI]: true,
+          },
         },
       });
     });
@@ -532,7 +654,10 @@ describe('SmartTransactionsController', () => {
       nock(API_BASE_URL)
         .get(`/networks/${ethereumChainIdDec}/batchStatus?uuids=uuid2`)
         .reply(200, successBatchStatusApiResponse);
-      await smartTransactionsController.fetchSmartTransactionsStatus(uuids);
+
+      await smartTransactionsController.fetchSmartTransactionsStatus(uuids, {
+        networkClientId: 'mainnet',
+      });
       const successState = createStateAfterSuccess()[0];
       const successTransaction = { ...successState, history: [successState] };
       expect(smartTransactionsController.state).toStrictEqual({
@@ -550,6 +675,20 @@ describe('SmartTransactionsController', () => {
             tradeTxFees: undefined,
           },
           liveness: true,
+          feesByChainId: {
+            '0x1': {
+              approvalTxFees: undefined,
+              tradeTxFees: undefined,
+            },
+            '0x5': {
+              approvalTxFees: undefined,
+              tradeTxFees: undefined,
+            },
+          },
+          livenessByChainId: {
+            '0x1': true,
+            '0x5': true,
+          },
         },
       });
     });
@@ -563,6 +702,32 @@ describe('SmartTransactionsController', () => {
         .reply(200, successLivenessApiResponse);
       const liveness = await smartTransactionsController.fetchLiveness();
       expect(liveness).toBe(true);
+    });
+
+    it('fetches liveness and sets in feesByChainId state for the Smart Transactions API for the chainId of the networkClientId passed in', async () => {
+      nock(API_BASE_URL)
+        .get(`/networks/${goerliChainIdDec}/health`)
+        .replyWithError('random error');
+
+      expect(
+        smartTransactionsController.state.smartTransactionsState
+          .livenessByChainId,
+      ).toStrictEqual({
+        [CHAIN_IDS.ETHEREUM]: true,
+        [CHAIN_IDS.GOERLI]: true,
+      });
+
+      await smartTransactionsController.fetchLiveness({
+        networkClientId: 'goerli',
+      });
+
+      expect(
+        smartTransactionsController.state.smartTransactionsState
+          .livenessByChainId,
+      ).toStrictEqual({
+        [CHAIN_IDS.ETHEREUM]: true,
+        [CHAIN_IDS.GOERLI]: false,
+      });
     });
   });
 
@@ -592,6 +757,9 @@ describe('SmartTransactionsController', () => {
       };
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
+        {
+          networkClientId: 'mainnet',
+        },
       );
 
       expect(
@@ -602,10 +770,6 @@ describe('SmartTransactionsController', () => {
 
     it('confirms a smart transaction that has status success', async () => {
       const { smartTransactionsState } = smartTransactionsController.state;
-      const confirmSpy = jest.spyOn(
-        smartTransactionsController,
-        'confirmSmartTransaction',
-      );
       const pendingStx = {
         ...createStateAfterPending()[0],
         history: testHistory,
@@ -620,44 +784,27 @@ describe('SmartTransactionsController', () => {
       });
       const updateTransaction = {
         ...pendingStx,
-        status: 'success',
+        status: SmartTransactionStatuses.SUCCESS,
       };
+
       smartTransactionsController.updateSmartTransaction(
         updateTransaction as SmartTransaction,
+        {
+          networkClientId: 'mainnet',
+        },
       );
-      expect(confirmSpy).toHaveBeenCalled();
-    });
-  });
 
-  describe('confirmSmartTransaction', () => {
-    beforeEach(() => {
-      // eslint-disable-next-line jest/prefer-spy-on
-      smartTransactionsController.checkPoll = jest.fn(() => ({}));
-    });
+      await flushPromises();
 
-    it('calls confirm external transaction', async () => {
-      const successfulStx = {
-        ...createStateAfterSuccess()[0],
-        history: testHistory,
-      };
-      await smartTransactionsController.confirmSmartTransaction(
-        successfulStx as SmartTransaction,
-      );
-      expect(confirmExternalMock).toHaveBeenCalled();
-    });
-
-    it('throws an error if ethersProvider fails', async () => {
-      smartTransactionsController.ethersProvider.getTransactionReceipt.mockRejectedValueOnce(
-        'random error' as never,
-      );
-      const successfulStx = {
-        ...createStateAfterSuccess()[0],
-        history: testHistory,
-      };
-      await smartTransactionsController.confirmSmartTransaction(
-        successfulStx as SmartTransaction,
-      );
-      expect(trackMetaMetricsEventSpy).toHaveBeenCalled();
+      expect(
+        smartTransactionsController.state.smartTransactionsState
+          .smartTransactions[CHAIN_IDS.ETHEREUM],
+      ).toStrictEqual([
+        {
+          ...updateTransaction,
+          confirmed: true,
+        },
+      ]);
     });
   });
 
@@ -742,6 +889,139 @@ describe('SmartTransactionsController', () => {
       });
       const actual = smartTransactionsController.isNewSmartTransaction('uuid1');
       expect(actual).toBe(false);
+    });
+  });
+
+  describe('startPollingByNetworkClientId', () => {
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('starts and stops calling smart transactions batch status api endpoint with the correct chainId at the polling interval', async () => {
+      // mock this to a noop because it causes an extra fetch call to the API upon state changes
+      jest
+        .spyOn(smartTransactionsController, 'checkPoll')
+        .mockImplementation(() => undefined);
+
+      // pending transactions in state are required to test polling
+      smartTransactionsController.update({
+        smartTransactionsState: {
+          ...defaultState.smartTransactionsState,
+          smartTransactions: {
+            '0x1': [
+              {
+                uuid: 'uuid1',
+                status: 'pending',
+                cancellable: true,
+                chainId: '0x1',
+              },
+            ],
+            '0x5': [
+              {
+                uuid: 'uuid2',
+                status: 'pending',
+                cancellable: true,
+                chainId: '0x5',
+              },
+            ],
+          },
+        },
+      });
+
+      const handleFetchSpy = jest.spyOn(utils, 'handleFetch');
+
+      const mainnetPollingToken =
+        smartTransactionsController.startPollingByNetworkClientId('mainnet');
+
+      await advanceTime({ clock, duration: 0 });
+
+      expect(
+        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
+      ).toStrictEqual(
+        JSON.stringify([
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.ETHEREUM,
+          )}/batchStatus?uuids=uuid1`,
+        ]),
+      );
+
+      handleFetchSpy.mockClear();
+      await advanceTime({ clock, duration: DEFAULT_INTERVAL });
+
+      expect(
+        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
+      ).toStrictEqual(
+        JSON.stringify([
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.ETHEREUM,
+          )}/batchStatus?uuids=uuid1`,
+        ]),
+      );
+
+      handleFetchSpy.mockClear();
+      smartTransactionsController.startPollingByNetworkClientId('goerli');
+      await advanceTime({ clock, duration: 0 });
+
+      expect(
+        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
+      ).toStrictEqual(
+        JSON.stringify([
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.GOERLI,
+          )}/batchStatus?uuids=uuid2`,
+        ]),
+      );
+
+      handleFetchSpy.mockClear();
+      await advanceTime({ clock, duration: DEFAULT_INTERVAL });
+
+      expect(
+        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
+      ).toStrictEqual(
+        JSON.stringify([
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.ETHEREUM,
+          )}/batchStatus?uuids=uuid1`,
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.GOERLI,
+          )}/batchStatus?uuids=uuid2`,
+        ]),
+      );
+
+      // stop the mainnet polling
+      smartTransactionsController.stopPollingByPollingToken(
+        mainnetPollingToken,
+      );
+
+      // cycle two polling intervals
+      handleFetchSpy.mockClear();
+      await advanceTime({ clock, duration: DEFAULT_INTERVAL });
+
+      await advanceTime({ clock, duration: DEFAULT_INTERVAL });
+
+      // check that the mainnet polling has stopped while the goerli polling continues
+      expect(
+        JSON.stringify(handleFetchSpy.mock.calls.map((arg) => arg[0])),
+      ).toStrictEqual(
+        JSON.stringify([
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.GOERLI,
+          )}/batchStatus?uuids=uuid2`,
+          `${API_BASE_URL}/networks/${convertHexToDecimal(
+            CHAIN_IDS.GOERLI,
+          )}/batchStatus?uuids=uuid2`,
+        ]),
+      );
+
+      // cleanup
+      smartTransactionsController.update(defaultState);
+
+      smartTransactionsController.stopAllPolling();
     });
   });
 });

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -298,7 +298,6 @@ export default class SmartTransactionsController extends PollingControllerV1<
     if (networkClientId) {
       const networkClient = this.getNetworkClientById(networkClientId);
       chainId = networkClient.configuration.chainId;
-      // @ts-expect-error TODO: Provider type alignment
       ethQuery = new EthQuery(networkClient.provider);
     }
 
@@ -708,8 +707,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
     networkClientId?: NetworkClientId;
   }): EthQuery {
     return networkClientId
-      ? // @ts-expect-error TODO: Provider type alignment
-        new EthQuery(this.getNetworkClientById(networkClientId).provider)
+      ? new EthQuery(this.getNetworkClientById(networkClientId).provider)
       : this.ethQuery;
   }
 

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -149,14 +149,15 @@ export default class SmartTransactionsController extends PollingControllerV1<
         },
       },
     };
-    this.setIntervalLength(this.config.interval || DEFAULT_INTERVAL);
+
+    this.initialize();
+    this.setIntervalLength(this.config.interval);
     this.getNonceLock = getNonceLock;
     this.ethQuery = new EthQuery(provider);
     this.confirmExternalTransaction = confirmExternalTransaction;
     this.trackMetaMetricsEvent = trackMetaMetricsEvent;
     this.getNetworkClientById = getNetworkClientById;
 
-    this.initialize();
     this.initializeSmartTransactionsForChainId();
 
     onNetworkStateChange(({ providerConfig: newProvider }) => {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -71,7 +71,7 @@ export default class SmartTransactionsController extends PollingControllerV1<
 
   private getNonceLock: any;
 
-  public ethQuery: EthQuery;
+  private ethQuery: EthQuery;
 
   public confirmExternalTransaction: any;
 

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -1,17 +1,15 @@
+import { BaseConfig, BaseState } from '@metamask/base-controller';
+import { ChainId, safelyExecute, query } from '@metamask/controller-utils';
 import {
-  BaseConfig,
-  BaseController,
-  BaseState,
-} from '@metamask/base-controller';
-import { safelyExecute } from '@metamask/controller-utils';
-import { NetworkState } from '@metamask/network-controller';
+  NetworkState,
+  NetworkController,
+  NetworkClientId,
+} from '@metamask/network-controller';
+import EthQuery from '@metamask/eth-query';
+import { PollingControllerV1 } from '@metamask/polling-controller';
 import { BigNumber } from 'bignumber.js';
-import { BigNumber as ethersBigNumber } from '@ethersproject/bignumber';
-import { Web3Provider } from '@ethersproject/providers';
 import { hexlify } from '@ethersproject/bytes';
-import mapValues from 'lodash/mapValues';
 import cloneDeep from 'lodash/cloneDeep';
-
 import {
   APIType,
   SmartTransaction,
@@ -22,6 +20,7 @@ import {
   SmartTransactionStatuses,
   Fees,
   IndividualTxFees,
+  Hex,
 } from './types';
 import {
   getAPIRequestURL,
@@ -43,24 +42,28 @@ export const DEFAULT_INTERVAL = SECOND * 5;
 export type SmartTransactionsControllerConfig = BaseConfig & {
   interval: number;
   clientId: string;
-  chainId: string;
+  chainId: Hex;
   supportedChainIds: string[];
+};
+
+type FeeEstimates = {
+  approvalTxFees: IndividualTxFees | undefined;
+  tradeTxFees: IndividualTxFees | undefined;
 };
 
 export type SmartTransactionsControllerState = BaseState & {
   smartTransactionsState: {
-    smartTransactions: Record<string, SmartTransaction[]>;
+    smartTransactions: Record<Hex, SmartTransaction[]>;
     userOptIn: boolean | undefined;
     userOptInV2: boolean | undefined;
     liveness: boolean | undefined;
-    fees: {
-      approvalTxFees: IndividualTxFees | undefined;
-      tradeTxFees: IndividualTxFees | undefined;
-    };
+    fees: FeeEstimates;
+    feesByChainId: Record<Hex, FeeEstimates>;
+    livenessByChainId: Record<Hex, boolean>;
   };
 };
 
-export default class SmartTransactionsController extends BaseController<
+export default class SmartTransactionsController extends PollingControllerV1<
   SmartTransactionsControllerConfig,
   SmartTransactionsControllerState
 > {
@@ -68,11 +71,13 @@ export default class SmartTransactionsController extends BaseController<
 
   private getNonceLock: any;
 
-  public ethersProvider: any;
+  public ethQuery: EthQuery;
 
   public confirmExternalTransaction: any;
 
   private trackMetaMetricsEvent: any;
+
+  private getNetworkClientById: NetworkController['getNetworkClientById'];
 
   /* istanbul ignore next */
   private async fetch(request: string, options?: RequestInit) {
@@ -95,6 +100,7 @@ export default class SmartTransactionsController extends BaseController<
       provider,
       confirmExternalTransaction,
       trackMetaMetricsEvent,
+      getNetworkClientById,
     }: {
       onNetworkStateChange: (
         listener: (networkState: NetworkState) => void,
@@ -103,6 +109,7 @@ export default class SmartTransactionsController extends BaseController<
       provider: any;
       confirmExternalTransaction: any;
       trackMetaMetricsEvent: any;
+      getNetworkClientById: NetworkController['getNetworkClientById'];
     },
     config?: Partial<SmartTransactionsControllerConfig>,
     state?: Partial<SmartTransactionsControllerState>,
@@ -111,9 +118,9 @@ export default class SmartTransactionsController extends BaseController<
 
     this.defaultConfig = {
       interval: DEFAULT_INTERVAL,
-      chainId: CHAIN_IDS.ETHEREUM,
+      chainId: ChainId.mainnet,
       clientId: 'default',
-      supportedChainIds: [CHAIN_IDS.ETHEREUM, CHAIN_IDS.RINKEBY],
+      supportedChainIds: [CHAIN_IDS.ETHEREUM, CHAIN_IDS.GOERLI],
     };
 
     this.defaultState = {
@@ -126,13 +133,28 @@ export default class SmartTransactionsController extends BaseController<
           tradeTxFees: undefined,
         },
         liveness: true,
+        livenessByChainId: {
+          [CHAIN_IDS.ETHEREUM]: true,
+          [CHAIN_IDS.GOERLI]: true,
+        },
+        feesByChainId: {
+          [CHAIN_IDS.ETHEREUM]: {
+            approvalTxFees: undefined,
+            tradeTxFees: undefined,
+          },
+          [CHAIN_IDS.GOERLI]: {
+            approvalTxFees: undefined,
+            tradeTxFees: undefined,
+          },
+        },
       },
     };
-
+    this.setIntervalLength(this.config.interval || DEFAULT_INTERVAL);
     this.getNonceLock = getNonceLock;
-    this.ethersProvider = new Web3Provider(provider);
+    this.ethQuery = new EthQuery(provider);
     this.confirmExternalTransaction = confirmExternalTransaction;
     this.trackMetaMetricsEvent = trackMetaMetricsEvent;
+    this.getNetworkClientById = getNetworkClientById;
 
     this.initialize();
     this.initializeSmartTransactionsForChainId();
@@ -142,10 +164,22 @@ export default class SmartTransactionsController extends BaseController<
       this.configure({ chainId });
       this.initializeSmartTransactionsForChainId();
       this.checkPoll(this.state);
-      this.ethersProvider = new Web3Provider(provider);
+      this.ethQuery = new EthQuery(provider);
     });
 
     this.subscribe((currentState: any) => this.checkPoll(currentState));
+  }
+
+  _executePoll(networkClientId: string): Promise<void> {
+    // if this is going to be truly UI driven polling we shouldn't really reach here
+    // with a networkClientId that is not supported, but for now I'll add a check in case
+    // wondering if we should add some kind of predicate to the polling controller to check whether
+    // we should poll or not
+    const chainId = this.getChainId({ networkClientId });
+    if (!this.config.supportedChainIds.includes(chainId)) {
+      return Promise.resolve();
+    }
+    return this.updateSmartTransactions({ networkClientId });
   }
 
   checkPoll(state: any) {
@@ -255,8 +289,35 @@ export default class SmartTransactionsController extends BaseController<
     return currentIndex === -1 || currentIndex === undefined;
   }
 
-  updateSmartTransaction(smartTransaction: SmartTransaction): void {
-    const { chainId } = this.config;
+  updateSmartTransaction(
+    smartTransaction: SmartTransaction,
+    { networkClientId }: { networkClientId?: NetworkClientId } = {},
+  ) {
+    let { chainId } = this.config;
+    let { ethQuery } = this;
+    if (networkClientId) {
+      const networkClient = this.getNetworkClientById(networkClientId);
+      chainId = networkClient.configuration.chainId;
+      // @ts-expect-error TODO: Provider type alignment
+      ethQuery = new EthQuery(networkClient.provider);
+    }
+
+    this.#updateSmartTransaction(smartTransaction, {
+      chainId,
+      ethQuery,
+    });
+  }
+
+  #updateSmartTransaction(
+    smartTransaction: SmartTransaction,
+    {
+      chainId = this.config.chainId,
+      ethQuery = this.ethQuery,
+    }: {
+      chainId: Hex;
+      ethQuery: EthQuery;
+    },
+  ): void {
     const { smartTransactionsState } = this.state;
     const { smartTransactions } = smartTransactionsState;
     const currentSmartTransactions = smartTransactions[chainId];
@@ -266,6 +327,7 @@ export default class SmartTransactionsController extends BaseController<
     const isNewSmartTransaction = this.isNewSmartTransaction(
       smartTransaction.uuid,
     );
+
     this.trackStxStatusChange(
       smartTransaction,
       isNewSmartTransaction
@@ -275,7 +337,7 @@ export default class SmartTransactionsController extends BaseController<
 
     if (isNewSmartTransaction) {
       // add smart transaction
-      const cancelledNonceIndex = currentSmartTransactions.findIndex(
+      const cancelledNonceIndex = currentSmartTransactions?.findIndex(
         (stx: SmartTransaction) =>
           stx.txParams?.nonce === smartTransaction.txParams?.nonce &&
           stx.status?.startsWith('cancelled'),
@@ -289,7 +351,7 @@ export default class SmartTransactionsController extends BaseController<
               .slice(0, cancelledNonceIndex)
               .concat(currentSmartTransactions.slice(cancelledNonceIndex + 1))
               .concat(historifiedSmartTransaction)
-          : currentSmartTransactions.concat(historifiedSmartTransaction);
+          : currentSmartTransactions?.concat(historifiedSmartTransaction);
       this.update({
         smartTransactionsState: {
           ...smartTransactionsState,
@@ -313,7 +375,10 @@ export default class SmartTransactionsController extends BaseController<
         ...currentSmartTransaction,
         ...smartTransaction,
       };
-      this.confirmSmartTransaction(nextSmartTransaction);
+      this.#confirmSmartTransaction(nextSmartTransaction, {
+        chainId,
+        ethQuery,
+      });
     }
 
     this.update({
@@ -333,42 +398,58 @@ export default class SmartTransactionsController extends BaseController<
     });
   }
 
-  async updateSmartTransactions() {
+  async updateSmartTransactions({
+    networkClientId,
+  }: {
+    networkClientId?: NetworkClientId;
+  } = {}): Promise<void> {
     const { smartTransactions } = this.state.smartTransactionsState;
-    const { chainId } = this.config;
+    const chainId = this.getChainId({ networkClientId });
+    const smartTransactionsForChainId = smartTransactions?.[chainId];
 
-    const currentSmartTransactions = smartTransactions?.[chainId];
-
-    const transactionsToUpdate: string[] = currentSmartTransactions
+    const transactionsToUpdate: string[] = smartTransactionsForChainId
       .filter(isSmartTransactionPending)
       .map((smartTransaction) => smartTransaction.uuid);
 
     if (transactionsToUpdate.length > 0) {
-      this.fetchSmartTransactionsStatus(transactionsToUpdate);
+      this.fetchSmartTransactionsStatus(transactionsToUpdate, {
+        networkClientId,
+      });
     }
   }
 
-  async confirmSmartTransaction(smartTransaction: SmartTransaction) {
+  async #confirmSmartTransaction(
+    smartTransaction: SmartTransaction,
+    {
+      chainId = this.config.chainId,
+      ethQuery = this.ethQuery,
+    }: {
+      chainId: Hex;
+      ethQuery: EthQuery;
+    },
+  ) {
     const txHash = smartTransaction.statusMetadata?.minedHash;
     try {
-      const transactionReceipt =
-        await this.ethersProvider.getTransactionReceipt(txHash);
-      const transaction = await this.ethersProvider.getTransaction(txHash);
-      const maxFeePerGas = transaction.maxFeePerGas?.toHexString();
-      const maxPriorityFeePerGas =
-        transaction.maxPriorityFeePerGas?.toHexString();
+      const transactionReceipt: {
+        maxFeePerGas?: string;
+        maxPriorityFeePerGas?: string;
+        blockNumber: string;
+      } | null = await query(ethQuery, 'getTransactionReceipt', [txHash]);
+
+      const transaction: {
+        maxFeePerGas?: string;
+        maxPriorityFeePerGas?: string;
+      } | null = await query(ethQuery, 'getTransactionByHash', [txHash]);
+
+      const maxFeePerGas = transaction?.maxFeePerGas;
+      const maxPriorityFeePerGas = transaction?.maxPriorityFeePerGas;
       if (transactionReceipt?.blockNumber) {
-        const blockData = await this.ethersProvider.getBlock(
-          transactionReceipt?.blockNumber,
-          false,
+        const blockData: { baseFeePerGas?: string } | null = await query(
+          ethQuery,
+          'getBlockByNumber',
+          [transactionReceipt?.blockNumber, false],
         );
-        const baseFeePerGas = blockData?.baseFeePerGas.toHexString();
-        const txReceipt = mapValues(transactionReceipt, (value) => {
-          if (value instanceof ethersBigNumber) {
-            return value.toHexString();
-          }
-          return value;
-        });
+        const baseFeePerGas = blockData?.baseFeePerGas;
         const updatedTxParams = {
           ...smartTransaction.txParams,
           maxFeePerGas,
@@ -399,17 +480,25 @@ export default class SmartTransactionsController extends BaseController<
                 history: originalTxMeta.history.concat(entry),
               }
             : originalTxMeta;
-        this.confirmExternalTransaction(txMeta, txReceipt, baseFeePerGas);
+
+        this.confirmExternalTransaction(
+          txMeta,
+          transactionReceipt,
+          baseFeePerGas,
+        );
 
         this.trackMetaMetricsEvent({
           event: 'STX Confirmed',
           category: 'swaps',
         });
 
-        this.updateSmartTransaction({
-          ...smartTransaction,
-          confirmed: true,
-        });
+        this.#updateSmartTransaction(
+          {
+            ...smartTransaction,
+            confirmed: true,
+          },
+          { chainId, ethQuery },
+        );
       }
     } catch (e) {
       this.trackMetaMetricsEvent({
@@ -423,29 +512,31 @@ export default class SmartTransactionsController extends BaseController<
   // ! Ask backend API to accept list of uuids as params
   async fetchSmartTransactionsStatus(
     uuids: string[],
+    { networkClientId }: { networkClientId?: NetworkClientId } = {},
   ): Promise<SmartTransaction[]> {
-    const { chainId } = this.config;
-
     const params = new URLSearchParams({
       uuids: uuids.join(','),
     });
-
+    const chainId = this.getChainId({ networkClientId });
+    const ethQuery = this.getEthQuery({ networkClientId });
     const url = `${getAPIRequestURL(
       APIType.BATCH_STATUS,
       chainId,
     )}?${params.toString()}`;
 
     const data = await this.fetch(url);
-
     Object.entries(data).forEach(([uuid, stxStatus]) => {
-      this.updateSmartTransaction({
-        statusMetadata: stxStatus as SmartTransactionsStatus,
-        status: calculateStatus(stxStatus as SmartTransactionsStatus),
-        cancellable: isSmartTransactionCancellable(
-          stxStatus as SmartTransactionsStatus,
-        ),
-        uuid,
-      });
+      this.#updateSmartTransaction(
+        {
+          statusMetadata: stxStatus as SmartTransactionsStatus,
+          status: calculateStatus(stxStatus as SmartTransactionsStatus),
+          cancellable: isSmartTransactionCancellable(
+            stxStatus as SmartTransactionsStatus,
+          ),
+          uuid,
+        },
+        { chainId, ethQuery },
+      );
     });
 
     return data;
@@ -480,8 +571,9 @@ export default class SmartTransactionsController extends BaseController<
   async getFees(
     tradeTx: UnsignedTransaction,
     approvalTx: UnsignedTransaction,
+    { networkClientId }: { networkClientId?: NetworkClientId } = {},
   ): Promise<Fees> {
-    const { chainId } = this.config;
+    const chainId = this.getChainId({ networkClientId });
     const transactions = [];
     let unsignedTradeTransactionWithNonce;
     if (approvalTx) {
@@ -521,8 +613,16 @@ export default class SmartTransactionsController extends BaseController<
           approvalTxFees,
           tradeTxFees,
         },
+        feesByChainId: {
+          ...this.state.smartTransactionsState.feesByChainId,
+          [chainId]: {
+            approvalTxFees,
+            tradeTxFees,
+          },
+        },
       },
     });
+
     return {
       approvalTxFees,
       tradeTxFees,
@@ -535,12 +635,15 @@ export default class SmartTransactionsController extends BaseController<
     txParams,
     signedTransactions,
     signedCanceledTransactions,
+    networkClientId,
   }: {
     signedTransactions: SignedTransaction[];
     signedCanceledTransactions: SignedCanceledTransaction[];
     txParams?: any;
+    networkClientId?: NetworkClientId;
   }) {
-    const { chainId } = this.config;
+    const chainId = this.getChainId({ networkClientId });
+    const ethQuery = this.getEthQuery({ networkClientId });
     const data = await this.fetch(
       getAPIRequestURL(APIType.SUBMIT_TRANSACTIONS, chainId),
       {
@@ -554,12 +657,12 @@ export default class SmartTransactionsController extends BaseController<
     const time = Date.now();
     let preTxBalance;
     try {
-      const preTxBalanceBN = await this.ethersProvider.getBalance(
+      const preTxBalanceBN = await query(ethQuery, 'getBalance', [
         txParams?.from,
-      );
-      preTxBalance = new BigNumber(preTxBalanceBN.toHexString()).toString(16);
+      ]);
+      preTxBalance = new BigNumber(preTxBalanceBN).toString(16);
     } catch (e) {
-      console.error('ethers error', e);
+      console.error('provider error', e);
     }
     const nonceLock = await this.getNonceLock(txParams?.from);
     try {
@@ -569,16 +672,19 @@ export default class SmartTransactionsController extends BaseController<
       }
       const { nonceDetails } = nonceLock;
 
-      this.updateSmartTransaction({
-        chainId,
-        nonceDetails,
-        preTxBalance,
-        status: SmartTransactionStatuses.PENDING,
-        time,
-        txParams,
-        uuid: data.uuid,
-        cancellable: true,
-      });
+      this.#updateSmartTransaction(
+        {
+          chainId,
+          nonceDetails,
+          preTxBalance,
+          status: SmartTransactionStatuses.PENDING,
+          time,
+          txParams,
+          uuid: data.uuid,
+          cancellable: true,
+        },
+        { chainId, ethQuery },
+      );
     } finally {
       nonceLock.releaseLock();
     }
@@ -586,19 +692,49 @@ export default class SmartTransactionsController extends BaseController<
     return data;
   }
 
+  getChainId({
+    networkClientId,
+  }: { networkClientId?: NetworkClientId } = {}): Hex {
+    return networkClientId
+      ? this.getNetworkClientById(networkClientId).configuration.chainId
+      : this.config.chainId;
+  }
+
+  getEthQuery({
+    networkClientId,
+  }: {
+    networkClientId?: NetworkClientId;
+  }): EthQuery {
+    return networkClientId
+      ? // @ts-expect-error TODO: Provider type alignment
+        new EthQuery(this.getNetworkClientById(networkClientId).provider)
+      : this.ethQuery;
+  }
+
   // TODO: This should return if the cancellation was on chain or not (for nonce management)
   // After this successful call client must update nonce representative
   // in transaction controller external transactions list
-  async cancelSmartTransaction(uuid: string): Promise<void> {
-    const { chainId } = this.config;
+  async cancelSmartTransaction(
+    uuid: string,
+    {
+      networkClientId,
+    }: {
+      networkClientId?: NetworkClientId;
+    } = {},
+  ): Promise<void> {
+    const chainId = this.getChainId({ networkClientId });
     await this.fetch(getAPIRequestURL(APIType.CANCEL, chainId), {
       method: 'POST',
       body: JSON.stringify({ uuid }),
     });
   }
 
-  async fetchLiveness(): Promise<boolean> {
-    const { chainId } = this.config;
+  async fetchLiveness({
+    networkClientId,
+  }: {
+    networkClientId?: NetworkClientId;
+  } = {}): Promise<boolean> {
+    const chainId = this.getChainId({ networkClientId });
     let liveness = false;
     try {
       const response = await this.fetch(
@@ -613,8 +749,13 @@ export default class SmartTransactionsController extends BaseController<
       smartTransactionsState: {
         ...this.state.smartTransactionsState,
         liveness,
+        livenessByChainId: {
+          ...this.state.smartTransactionsState.livenessByChainId,
+          [chainId]: liveness,
+        },
       },
     });
+
     return liveness;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const API_BASE_URL = 'https://transaction.metaswap.codefi.network';
 export const CHAIN_IDS = {
   ETHEREUM: '0x1',
+  GOERLI: '0x5',
   RINKEBY: '0x4',
   BSC: '0x38',
-};
+} as const;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,7 +7,7 @@ describe('default export', () => {
     const controller = new DefaultExport({
       onNetworkStateChange: jest.fn(),
       getNonceLock: null,
-      provider: jest.fn(),
+      provider: { sendAsync: jest.fn() },
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
       getNetworkClientById: jest.fn(),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ describe('default export', () => {
       provider: jest.fn(),
       confirmExternalTransaction: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
+      getNetworkClientById: jest.fn(),
     });
     expect(controller).toBeInstanceOf(SmartTransactionsController);
     jest.clearAllTimers();

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve all pending promises.
+ * This method is used for async tests that use fake timers.
+ * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
+ */
+export const flushPromises = () => {
+  return new Promise(jest.requireActual('timers').setImmediate);
+};
+
+/**
+ * Advances the provided fake timer by a specified duration in incremental steps.
+ * Between each step, any enqueued promises are processed. Fake timers in testing libraries
+ * allow simulation of time without actually waiting. However, they don't always account for
+ * promises or other asynchronous operations that may get enqueued during the timer's duration.
+ * By advancing time in incremental steps and flushing promises between each step,
+ * this function ensures that both timers and promises are comprehensively processed.
+ * @param options - The options object.
+ * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
+ * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.
+ * @param options.stepSize - The incremental step size (in milliseconds) by which the timer is advanced in each iteration. Default is 1/4 of the duration.
+ */
+export async function advanceTime({
+  clock,
+  duration,
+  stepSize = duration / 4,
+}: {
+  clock: sinon.SinonFakeTimers;
+  duration: number;
+  stepSize?: number;
+}): Promise<void> {
+  do {
+    await clock.tickAsync(stepSize);
+    await flushPromises();
+    // eslint-disable-next-line no-param-reassign
+    duration -= stepSize;
+  } while (duration > 0);
+}

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -22,7 +22,7 @@ export const flushPromises = () => {
 export async function advanceTime({
   clock,
   duration,
-  stepSize = duration / 4,
+  stepSize = Math.floor(duration / 4),
 }: {
   clock: sinon.SinonFakeTimers;
   duration: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,3 +117,5 @@ export type SignedTransaction = any;
 
 // TODO
 export type SignedCanceledTransaction = any;
+
+export type Hex = `0x${string}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,77 +589,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abstract-provider@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-provider@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-  checksum: 74cf4696245cf03bb7cc5b6cbf7b4b89dd9a79a1c4688126d214153a938126d4972d42c93182198653ce1de35f2a2cad68be40337d4774b3698a39b28f0228a8
-  languageName: node
-  linkType: hard
-
-"@ethersproject/abstract-signer@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-signer@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: a823dac9cfb761e009851050ebebd5b229d1b1cc4a75b125c2da130ff37e8218208f7f9d1386f77407705b889b23d4a230ad67185f8872f083143e0073cbfbe3
-  languageName: node
-  linkType: hard
-
-"@ethersproject/address@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/address@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-  checksum: 64ea5ebea9cc0e845c413e6cb1e54e157dd9fc0dffb98e239d3a3efc8177f2ff798cd4e3206cf3660ee8faeb7bef1a47dc0ebef0d7b132c32e61e550c7d4c843
-  languageName: node
-  linkType: hard
-
-"@ethersproject/base64@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/base64@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-  checksum: 7dd5d734d623582f08f665434f53685041a3d3b334a0e96c0c8afa8bbcaab934d50e5b6b980e826a8fde8d353e0b18f11e61faf17468177274b8e7c69cd9742b
-  languageName: node
-  linkType: hard
-
-"@ethersproject/basex@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/basex@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: 326087b7e1f3787b5fe6cd1cf2b4b5abfafbc355a45e88e22e5e9d6c845b613ffc5301d629b28d5c4d5e2bfe9ec424e6782c804956dff79be05f0098cb5817de
-  languageName: node
-  linkType: hard
-
-"@ethersproject/bignumber@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/bignumber@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    bn.js: ^5.2.1
-  checksum: 8c9a134b76f3feb4ec26a5a27379efb4e156b8fb2de0678a67788a91c7f4e30abe9d948638458e4b20f2e42380da0adacc7c9389d05fce070692edc6ae9b4904
-  languageName: node
-  linkType: hard
-
 "@ethersproject/bytes@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/bytes@npm:5.7.0"
@@ -669,178 +598,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/constants@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/constants@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-  checksum: 6d4b1355747cce837b3e76ec3bde70e4732736f23b04f196f706ebfa5d4d9c2be50904a390d4d40ce77803b98d03d16a9b6898418e04ba63491933ce08c4ba8a
-  languageName: node
-  linkType: hard
-
-"@ethersproject/hash@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/hash@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 6e9fa8d14eb08171cd32f17f98cc108ec2aeca74a427655f0d689c550fee0b22a83b3b400fad7fb3f41cf14d4111f87f170aa7905bcbcd1173a55f21b06262ef
-  languageName: node
-  linkType: hard
-
-"@ethersproject/keccak256@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/keccak256@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    js-sha3: 0.8.0
-  checksum: ff70950d82203aab29ccda2553422cbac2e7a0c15c986bd20a69b13606ed8bb6e4fdd7b67b8d3b27d4f841e8222cbaccd33ed34be29f866fec7308f96ed244c6
-  languageName: node
-  linkType: hard
-
 "@ethersproject/logger@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/logger@npm:5.7.0"
   checksum: 075ab2f605f1fd0813f2e39c3308f77b44a67732b36e712d9bc085f22a84aac4da4f71b39bee50fe78da3e1c812673fadc41180c9970fe5e486e91ea17befe0d
-  languageName: node
-  linkType: hard
-
-"@ethersproject/networks@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/networks@npm:5.7.0"
-  dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 4f4d77e7c59e79cfcba616315a5d0e634a7653acbd11bb06a0028f4bd009b19f9a31556148a1e38f7308f55d1a1d170eb9f065290de9f9cf104b34e91cc348b8
-  languageName: node
-  linkType: hard
-
-"@ethersproject/properties@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/properties@npm:5.7.0"
-  dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 6ab0ccf0c3aadc9221e0cdc5306ce6cd0df7f89f77d77bccdd1277182c9ead0202cd7521329ba3acde130820bf8af299e17cf567d0d497c736ee918207bbf59f
-  languageName: node
-  linkType: hard
-
-"@ethersproject/providers@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/providers@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-    bech32: 1.1.4
-    ws: 7.4.6
-  checksum: a6f80cea838424ceb367ff8e0f004f9fd6b43a87505da9d6aef33eb2bbc77cdb03ab51709ae83b7aa07d038fadf00634e08d8683fe6ae8b17b9351e3b30b26cb
-  languageName: node
-  linkType: hard
-
-"@ethersproject/random@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/random@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 017829c91cff6c76470852855108115b0b52c611b6be817ed1948d56ba42d6677803ec2012aa5ae298a7660024156a64c11fcf544e235e239ab3f89f0fff7345
-  languageName: node
-  linkType: hard
-
-"@ethersproject/rlp@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/rlp@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: bce165b0f7e68e4d091c9d3cf47b247cac33252df77a095ca4281d32d5eeaaa3695d9bc06b2b057c5015353a68df89f13a4a54a72e888e4beeabbe56b15dda6e
-  languageName: node
-  linkType: hard
-
-"@ethersproject/sha2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/sha2@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    hash.js: 1.1.7
-  checksum: 09321057c022effbff4cc2d9b9558228690b5dd916329d75c4b1ffe32ba3d24b480a367a7cc92d0f0c0b1c896814d03351ae4630e2f1f7160be2bcfbde435dbc
-  languageName: node
-  linkType: hard
-
-"@ethersproject/signing-key@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/signing-key@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    bn.js: ^5.2.1
-    elliptic: 6.5.4
-    hash.js: 1.1.7
-  checksum: 8f8de09b0aac709683bbb49339bc0a4cd2f95598f3546436c65d6f3c3a847ffa98e06d35e9ed2b17d8030bd2f02db9b7bd2e11c5cf8a71aad4537487ab4cf03a
-  languageName: node
-  linkType: hard
-
-"@ethersproject/strings@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/strings@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 5ff78693ae3fdf3cf23e1f6dc047a61e44c8197d2408c42719fef8cb7b7b3613a4eec88ac0ed1f9f5558c74fe0de7ae3195a29ca91a239c74b9f444d8e8b50df
-  languageName: node
-  linkType: hard
-
-"@ethersproject/transactions@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/transactions@npm:5.7.0"
-  dependencies:
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-  checksum: a31b71996d2b283f68486241bff0d3ea3f1ba0e8f1322a8fffc239ccc4f4a7eb2ea9994b8fd2f093283fd75f87bae68171e01b6265261f821369aca319884a79
-  languageName: node
-  linkType: hard
-
-"@ethersproject/web@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/web@npm:5.7.0"
-  dependencies:
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 9d4ca82f8b1295bbc1c59d58cb351641802d2f70f4b7d523fc726f51b0615296da6d6585dee5749b4d5e4a6a9af6d6650d46fe562d5b04f43a0af5c7f7f4a77e
   languageName: node
   linkType: hard
 
@@ -1305,7 +1066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.3.0":
+"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.2.0, @metamask/eth-json-rpc-provider@npm:^2.3.0":
   version: 2.3.0
   resolution: "@metamask/eth-json-rpc-provider@npm:2.3.0"
   dependencies:
@@ -1350,7 +1111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.0":
+"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.2.0, @metamask/json-rpc-engine@npm:^7.3.0":
   version: 7.3.0
   resolution: "@metamask/json-rpc-engine@npm:7.3.0"
   dependencies:
@@ -1383,6 +1144,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/polling-controller@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@metamask/polling-controller@npm:1.0.1"
+  dependencies:
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/controller-utils": ^5.0.2
+    "@metamask/network-controller": ^15.1.0
+    "@metamask/utils": ^8.1.0
+    "@types/uuid": ^8.3.0
+    fast-json-stable-stringify: ^2.1.0
+    uuid: ^8.3.2
+  peerDependencies:
+    "@metamask/network-controller": ^15.1.0
+  checksum: a3f929cb2f65627ee69ce44f2a0463cd17c0de9d7075e02fbc23d4d27317531de9df061c9b0ff955a141b8c03135fb14d445e525b0e4de963466acf7f518e668
+  languageName: node
+  linkType: hard
+
 "@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/rpc-errors@npm:6.1.0"
@@ -1404,9 +1182,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/smart-transactions-controller@workspace:."
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
     "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/providers": ^5.7.0
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
@@ -1416,9 +1192,12 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
     "@metamask/network-controller": ^17.0.0
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/polling-controller": ^1.0.1
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^16.18.31
+    "@types/sinon": ^9.0.10
     "@typescript-eslint/eslint-plugin": ^5.33.0
     "@typescript-eslint/parser": ^5.33.0
     bignumber.js: ^9.0.1
@@ -1436,6 +1215,7 @@ __metadata:
     nock: ^13.3.1
     prettier: ^2.8.8
     prettier-plugin-packagejson: ^2.4.3
+    sinon: ^9.2.4
     ts-jest: ^26.5.6
     typescript: ~4.4.4
   languageName: unknown
@@ -1612,6 +1392,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.8.1":
+  version: 1.8.6
+  resolution: "@sinonjs/commons@npm:1.8.6"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 7d3f8c1e85f30cd4e83594fc19b7a657f14d49eb8d95a30095631ce15e906c869e0eff96c5b93dffea7490c00418b07f54582ba49c6560feb2a8c34c0b16832d
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^1.7.0":
   version: 1.8.1
   resolution: "@sinonjs/commons@npm:1.8.1"
@@ -1621,12 +1410,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^6.0.1":
+"@sinonjs/fake-timers@npm:^6.0.0, @sinonjs/fake-timers@npm:^6.0.1":
   version: 6.0.1
   resolution: "@sinonjs/fake-timers@npm:6.0.1"
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 8e331aa1412d905ecc8efd63550f58a6f77dcb510f878172004e53be63eb82650623618763001a918fc5e21257b86c45041e4e97c454ed6a2d187de084abbd11
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@sinonjs/samsam@npm:5.3.1"
+  dependencies:
+    "@sinonjs/commons": ^1.6.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: 1c2c49d51b1840775980e9496707d68b936f443896f92e48150c4f7713d14904e576740e52660b602f8a53b665bd5f149c5c733758030758427ddb1621090279
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@sinonjs/text-encoding@npm:0.7.2"
+  checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
   languageName: node
   linkType: hard
 
@@ -1837,10 +1644,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sinon@npm:^9.0.10":
+  version: 9.0.11
+  resolution: "@types/sinon@npm:9.0.11"
+  dependencies:
+    "@types/sinonjs__fake-timers": "*"
+  checksum: 2074490973012283ec9ccb9f607fa12f36c78d8801f63ec437d3e8351dae161a018836cc02e8b039118ec9fb7680331594716ed0858075a11d381edd27faa75c
+  languageName: node
+  linkType: hard
+
+"@types/sinonjs__fake-timers@npm:*":
+  version: 8.1.5
+  resolution: "@types/sinonjs__fake-timers@npm:8.1.5"
+  checksum: 7e3c08f6c13df44f3ea7d9a5155ddf77e3f7314c156fa1c5a829a4f3763bafe2f75b1283b887f06e6b4296996a2f299b70f64ff82625f9af5885436e2524d10c
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^8.3.0":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
   languageName: node
   linkType: hard
 
@@ -2444,13 +2274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bech32@npm:1.1.4":
-  version: 1.1.4
-  resolution: "bech32@npm:1.1.4"
-  checksum: 0e98db619191548390d6f09ff68b0253ba7ae6a55db93dfdbb070ba234c1fd3308c0606fbcc95fad50437227b10011e2698b89f0181f6e7f845c499bd14d0f4b
-  languageName: node
-  linkType: hard
-
 "big-integer@npm:^1.6.44":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
@@ -2498,7 +2321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.1.2, bn.js@npm:^5.2.1":
+"bn.js@npm:^5.1.2":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3
@@ -3276,6 +3099,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
+  languageName: node
+  linkType: hard
+
 "diff@npm:^5.0.0":
   version: 5.0.0
   resolution: "diff@npm:5.0.0"
@@ -3336,7 +3166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.5.2":
+"elliptic@npm:^6.5.2":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -4096,7 +3926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -4676,7 +4506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -5293,6 +5123,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
+  languageName: node
+  linkType: hard
+
 "isarray@npm:1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
@@ -5858,13 +5695,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sha3@npm:0.8.0":
-  version: 0.8.0
-  resolution: "js-sha3@npm:0.8.0"
-  checksum: 75df77c1fc266973f06cce8309ce010e9e9f07ec35ab12022ed29b7f0d9c8757f5a73e1b35aa24840dced0dea7059085aa143d817aea9e188e2a80d569d9adce
-  languageName: node
-  linkType: hard
-
 "js-sha3@npm:^0.5.7":
   version: 0.5.7
   resolution: "js-sha3@npm:0.5.7"
@@ -6045,6 +5875,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^4.0.2":
+  version: 4.2.1
+  resolution: "just-extend@npm:4.2.1"
+  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
+  languageName: node
+  linkType: hard
+
 "keccak@npm:^3.0.0":
   version: 3.0.2
   resolution: "keccak@npm:3.0.2"
@@ -6152,6 +5989,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
   languageName: node
   linkType: hard
 
@@ -6552,6 +6396,19 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
+  languageName: node
+  linkType: hard
+
+"nise@npm:^4.0.4":
+  version: 4.1.0
+  resolution: "nise@npm:4.1.0"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+    "@sinonjs/fake-timers": ^6.0.0
+    "@sinonjs/text-encoding": ^0.7.1
+    just-extend: ^4.0.2
+    path-to-regexp: ^1.7.0
+  checksum: b2ea1c96a41c392adf746509904af565ebd667ad4e40267f6d73be3648f04267945624ba0ce6a991b779f3ae246181f71975152b93b4dafee1f62886fa897c32
   languageName: node
   linkType: hard
 
@@ -7038,6 +6895,15 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "path-to-regexp@npm:1.8.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
   languageName: node
   linkType: hard
 
@@ -7812,6 +7678,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^9.2.4":
+  version: 9.2.4
+  resolution: "sinon@npm:9.2.4"
+  dependencies:
+    "@sinonjs/commons": ^1.8.1
+    "@sinonjs/fake-timers": ^6.0.1
+    "@sinonjs/samsam": ^5.3.1
+    diff: ^4.0.2
+    nise: ^4.0.4
+    supports-color: ^7.1.0
+  checksum: 34b881886daa4b491bb9147ccad43d662f58b45a1b6f1e8b26a405ad77041108306fac3648646335f00f702897f0ba12282588ab64de470f48f1a7678e08dc65
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.4":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -8514,7 +8394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
@@ -8975,7 +8855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.6, ws@npm:^7.4.4":
+"ws@npm:^7.4.4":
   version: 7.4.6
   resolution: "ws@npm:7.4.6"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,16 +952,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "@metamask/base-controller@npm:3.2.3"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
-  languageName: node
-  linkType: hard
-
 "@metamask/base-controller@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/base-controller@npm:4.0.0"
@@ -972,32 +962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@metamask/controller-utils@npm:5.0.2"
-  dependencies:
-    "@metamask/utils": ^8.2.0
-    immer: ^9.0.6
-  checksum: a3ac2d54a8d540f1f160ce657d9127e8f3a3f4685834eba3913be8dfa577eea7cc00e4e98ebedd42d6c190e0949e296c7ef9c10b3f8bffcb0b33bdff6e7bafc1
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "@metamask/controller-utils@npm:6.1.0"
-  dependencies:
-    "@metamask/eth-query": ^4.0.0
-    "@metamask/ethjs-unit": ^0.2.1
-    "@metamask/utils": ^8.2.0
-    "@spruceid/siwe-parser": 1.1.3
-    eth-ens-namehash: ^2.0.8
-    ethereumjs-util: ^7.0.10
-    fast-deep-equal: ^3.1.3
-  checksum: 0f0f9a5bc199f9a6c75926f12fa52bd486634091dfbb2db2b98f49b6a09407da9edc0b4a14613ea5c65d8b6cd1f4817acb0e5cffc9b0586f90084e440bf81322
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^6.1.0":
+"@metamask/controller-utils@npm:^6.0.0, @metamask/controller-utils@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/controller-utils@npm:6.1.0"
   dependencies:
@@ -1091,7 +1056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.2.0, @metamask/eth-json-rpc-provider@npm:^2.3.0":
+"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.3.0":
   version: 2.3.0
   resolution: "@metamask/eth-json-rpc-provider@npm:2.3.0"
   dependencies:
@@ -1136,17 +1101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ethjs-unit@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@metamask/ethjs-unit@npm:0.2.1"
-  dependencies:
-    bn.js: 4.11.6
-    number-to-bn: 1.7.0
-  checksum: 0c8bbbe06000f647b46701fcf976e29b67c7362b3ae252d8d4fe2feb74f3988c1203eb03cc34bb899101f01812c8c300158d75bc721d649124c048e8b149b557
-  languageName: node
-  linkType: hard
-
-"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.2.0, @metamask/json-rpc-engine@npm:^7.3.0":
+"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.0":
   version: 7.3.0
   resolution: "@metamask/json-rpc-engine@npm:7.3.0"
   dependencies:
@@ -1179,20 +1134,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/polling-controller@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@metamask/polling-controller@npm:1.0.1"
+"@metamask/polling-controller@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/polling-controller@npm:2.0.0"
   dependencies:
-    "@metamask/base-controller": ^3.2.3
-    "@metamask/controller-utils": ^5.0.2
-    "@metamask/network-controller": ^15.1.0
-    "@metamask/utils": ^8.1.0
+    "@metamask/base-controller": ^4.0.0
+    "@metamask/controller-utils": ^6.0.0
+    "@metamask/network-controller": ^17.0.0
+    "@metamask/utils": ^8.2.0
     "@types/uuid": ^8.3.0
     fast-json-stable-stringify: ^2.1.0
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^15.1.0
-  checksum: a3f929cb2f65627ee69ce44f2a0463cd17c0de9d7075e02fbc23d4d27317531de9df061c9b0ff955a141b8c03135fb14d445e525b0e4de963466acf7f518e668
+    "@metamask/network-controller": ^17.0.0
+  checksum: 7bfa407ddcabbf6f26762066ae0586311a26b4652f1c9decea60b3455b059196d70efa9fcae5eacca93f84be40866ca2687c844d19254206b12229f925ab72c5
   languageName: node
   linkType: hard
 
@@ -1226,9 +1181,9 @@ __metadata:
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
-    "@metamask/network-controller": ^17.0.0
     "@metamask/eth-query": ^4.0.0
-    "@metamask/polling-controller": ^1.0.1
+    "@metamask/network-controller": ^17.0.0
+    "@metamask/polling-controller": ^2.0.0
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^16.18.31

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,7 +952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.2.1":
+"@metamask/base-controller@npm:^3.2.3":
   version: 3.2.3
   resolution: "@metamask/base-controller@npm:3.2.3"
   dependencies:
@@ -972,7 +972,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/controller-utils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/controller-utils@npm:5.0.2"
+  dependencies:
+    "@metamask/utils": ^8.2.0
+    immer: ^9.0.6
+  checksum: a3ac2d54a8d540f1f160ce657d9127e8f3a3f4685834eba3913be8dfa577eea7cc00e4e98ebedd42d6c190e0949e296c7ef9c10b3f8bffcb0b33bdff6e7bafc1
+  languageName: node
+  linkType: hard
+
 "@metamask/controller-utils@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "@metamask/controller-utils@npm:6.1.0"
+  dependencies:
+    "@metamask/eth-query": ^4.0.0
+    "@metamask/ethjs-unit": ^0.2.1
+    "@metamask/utils": ^8.2.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    ethereumjs-util: ^7.0.10
+    fast-deep-equal: ^3.1.3
+  checksum: 0f0f9a5bc199f9a6c75926f12fa52bd486634091dfbb2db2b98f49b6a09407da9edc0b4a14613ea5c65d8b6cd1f4817acb0e5cffc9b0586f90084e440bf81322
+  languageName: node
+  linkType: hard
+
+"@metamask/controller-utils@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/controller-utils@npm:6.1.0"
   dependencies:
@@ -1111,6 +1136,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ethjs-unit@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@metamask/ethjs-unit@npm:0.2.1"
+  dependencies:
+    bn.js: 4.11.6
+    number-to-bn: 1.7.0
+  checksum: 0c8bbbe06000f647b46701fcf976e29b67c7362b3ae252d8d4fe2feb74f3988c1203eb03cc34bb899101f01812c8c300158d75bc721d649124c048e8b149b557
+  languageName: node
+  linkType: hard
+
 "@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.2.0, @metamask/json-rpc-engine@npm:^7.3.0":
   version: 7.3.0
   resolution: "@metamask/json-rpc-engine@npm:7.3.0"
@@ -1185,14 +1220,14 @@ __metadata:
     "@ethersproject/bytes": ^5.7.0
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^6.0.0
+    "@metamask/base-controller": ^4.0.0
+    "@metamask/controller-utils": ^6.1.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
     "@metamask/network-controller": ^17.0.0
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/polling-controller": ^1.0.1
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194


### PR DESCRIPTION
~TODO:~
- [x] ~E2E test with extension to ensure working properly before taking out of draft~

Working e2e test here:
https://github.com/MetaMask/smart-transactions-controller/assets/34557516/307de2da-1fe3-43c8-8faa-7bf51da28eaa

Resolves: https://github.com/MetaMask/MetaMask-planning/issues/1039

Integrates new `PollingController` abstraction into the `SmartTransactionsController`, implements the `_executePoll` method and parameterizes the `updateSmartTransactions` method by `networkClientId` such that pending SmartTransaction statuses can be polled for concurrently across different chains.

A note: As is our current controller refactor strategy, these changes are additive, backwards compatible and coexist alongside the existing globally selected network pattern. Once we fully adopt this polling pattern we should no longer access the root liveness and fees state but rather access these values by chainId from `livenessByChainId` and `feesByChainId`.

### Added
- Integrates `PollingController` mixin into the `SmartTransactionsController` and implements the abstract `_executePoll` method.
### Changed
- Adds optional options object containing a `networkClientId` argument to the `updateSmartTransaction` method which, if passed, is used fetch the chainId that corresponds to the networkClientId and is then used to fetch and update the status of pending smart transactions for that chainId.