### PR TITLE
[v6.x] Delay `ethersProvider` instantiation until network provider is available

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
-import { NetworkState } from '@metamask/network-controller';
+import { NetworkType } from '@metamask/controller-utils';
+import { NetworkState, NetworkStatus } from '@metamask/network-controller';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import packageJson from '../package.json';
@@ -255,13 +256,47 @@ const ethereumChainIdDec = parseInt(CHAIN_IDS.ETHEREUM, 16);
 
 const trackMetaMetricsEventSpy = jest.fn();
 
+const mockProvider = {
+  sendAsync: jest.fn(),
+};
+
+const mockProviderConfig = {
+  chainId: '0x1' as `0x${string}`,
+  provider: mockProvider,
+  type: NetworkType.mainnet,
+  ticker: 'ticker',
+};
+
+const mockNetworkState = {
+  providerConfig: mockProviderConfig,
+  selectedNetworkClientId: 'id',
+  networkConfigurations: {
+    id: {
+      id: 'id',
+      rpcUrl: 'string',
+      chainId: '0x1' as `0x${string}`,
+      ticker: 'string',
+    },
+  },
+  networksMetadata: {
+    id: {
+      EIPS: {
+        1155: true,
+      },
+      status: NetworkStatus.Available,
+    },
+  },
+};
+
 describe('SmartTransactionsController', () => {
   let smartTransactionsController: SmartTransactionsController;
   let networkListener: (networkState: NetworkState) => void;
 
   beforeEach(() => {
     smartTransactionsController = new SmartTransactionsController({
-      onNetworkStateChange: (listener) => {
+      onNetworkStateChange: (
+        listener: (networkState: NetworkState) => void,
+      ) => {
         networkListener = listener;
       },
       getNonceLock: jest.fn(() => {
@@ -276,6 +311,8 @@ describe('SmartTransactionsController', () => {
     });
     // eslint-disable-next-line jest/prefer-spy-on
     smartTransactionsController.subscribe = jest.fn();
+
+    networkListener(mockNetworkState);
   });
 
   afterEach(async () => {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -549,6 +549,9 @@ export default class SmartTransactionsController extends BaseController<
     signedCanceledTransactions: SignedCanceledTransaction[];
     txParams?: any;
   }) {
+    if (this.ethersProvider === undefined) {
+      throw new Error(MISSING_PROVIDER_ERROR_MSG);
+    }
     const { chainId } = this.config;
     const data = await this.fetch(
       getAPIRequestURL(APIType.SUBMIT_TRANSACTIONS, chainId),

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -37,6 +37,8 @@ import {
 } from './utils';
 import { CHAIN_IDS } from './constants';
 
+const MISSING_PROVIDER_ERROR_MSG =
+  '`ethersProvider` is not defined on SmartTransactionsController';
 const SECOND = 1000;
 export const DEFAULT_INTERVAL = SECOND * 5;
 
@@ -256,6 +258,9 @@ export default class SmartTransactionsController extends BaseController<
   }
 
   updateSmartTransaction(smartTransaction: SmartTransaction): void {
+    if (this.ethersProvider === undefined) {
+      throw new Error(MISSING_PROVIDER_ERROR_MSG);
+    }
     const { chainId } = this.config;
     const { smartTransactionsState } = this.state;
     const { smartTransactions } = smartTransactionsState;
@@ -266,6 +271,7 @@ export default class SmartTransactionsController extends BaseController<
     const isNewSmartTransaction = this.isNewSmartTransaction(
       smartTransaction.uuid,
     );
+
     this.trackStxStatusChange(
       smartTransaction,
       isNewSmartTransaction
@@ -349,6 +355,9 @@ export default class SmartTransactionsController extends BaseController<
   }
 
   async confirmSmartTransaction(smartTransaction: SmartTransaction) {
+    if (this.ethersProvider === undefined) {
+      throw new Error(MISSING_PROVIDER_ERROR_MSG);
+    }
     const txHash = smartTransaction.statusMetadata?.minedHash;
     try {
       const transactionReceipt =


### PR DESCRIPTION
- #274 backported targeting v6 (current in metamask-extension)