### PR TITLE
Update domain name for transaction-api, add a new function "getSmartTransactionByMinedTxHash"

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1186,6 +1186,48 @@ describe('SmartTransactionsController', () => {
     });
   });
 
+  describe('getSmartTransactionByMinedTxHash', () => {
+    it('retrieves a smart transaction by a mined tx hash', () => {
+      const { smartTransactionsState } = smartTransactionsController.state;
+      const successfulSmartTransaction = createStateAfterSuccess()[0];
+      smartTransactionsController.update({
+        smartTransactionsState: {
+          ...smartTransactionsState,
+          smartTransactions: {
+            [CHAIN_IDS.ETHEREUM]: [
+              successfulSmartTransaction,
+            ] as SmartTransaction[],
+          },
+        },
+      });
+      const smartTransaction =
+        smartTransactionsController.getSmartTransactionByMinedTxHash(
+          successfulSmartTransaction.statusMetadata.minedHash,
+        );
+      expect(smartTransaction).toStrictEqual(successfulSmartTransaction);
+    });
+
+    it('returns undefined if there is no smart transaction found by tx hash', () => {
+      const { smartTransactionsState } = smartTransactionsController.state;
+      const successfulSmartTransaction = createStateAfterSuccess()[0];
+      smartTransactionsController.update({
+        smartTransactionsState: {
+          ...smartTransactionsState,
+          smartTransactions: {
+            [CHAIN_IDS.ETHEREUM]: [
+              successfulSmartTransaction,
+            ] as SmartTransaction[],
+          },
+        },
+      });
+      const smartTransaction =
+        smartTransactionsController.getSmartTransactionByMinedTxHash(
+          'nonStxTxHash',
+        );
+      expect(smartTransaction).toBeUndefined();
+    });
+  });
+
   describe('isNewSmartTransaction', () => {
     it('returns true if it is a new STX', () => {
       const actual =

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -852,6 +852,16 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
     }
   }
 
+  #getCurrentSmartTransactions(): SmartTransaction[] {
+    const { smartTransactions } = this.state.smartTransactionsState;
+    const { chainId } = this.config;
+    const currentSmartTransactions = smartTransactions?.[chainId];
+    if (!currentSmartTransactions || currentSmartTransactions.length === 0) {
+      return [];
+    }
+    return currentSmartTransactions;
+  }
+
   getTransactions({
     addressFrom,
     status,
@@ -859,15 +869,24 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
     addressFrom: string;
     status: SmartTransactionStatuses;
   }): SmartTransaction[] {
-    const { smartTransactions } = this.state.smartTransactionsState;
-    const { chainId } = this.config;
-    const currentSmartTransactions = smartTransactions?.[chainId];
-    if (!currentSmartTransactions || currentSmartTransactions.length === 0) {
-      return [];
-    }
-
+    const currentSmartTransactions = this.#getCurrentSmartTransactions();
     return currentSmartTransactions.filter((stx) => {
       return stx.status === status && stx.txParams?.from === addressFrom;
+    });
+  }
+
+  getSmartTransactionByMinedTxHash(
+    txHash: string | undefined,
+  ): SmartTransaction | undefined {
+    if (!txHash) {
+      return undefined;
+    }
+    const currentSmartTransactions = this.#getCurrentSmartTransactions();
+    return currentSmartTransactions.find((smartTransaction) => {
+      return (
+        smartTransaction.statusMetadata?.minedHash?.toLowerCase() ===
+        txHash.toLowerCase()
+      );
     });
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'https://transaction.uat-api.cx.metamask.io';
+export const API_BASE_URL = 'https://transaction.api.cx.metamask.io';
 export const CHAIN_IDS = {
   ETHEREUM: '0x1',
   GOERLI: '0x5',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'https://transaction.metaswap.codefi.network';
+export const API_BASE_URL = 'https://transaction.uat-api.cx.metamask.io';
 export const CHAIN_IDS = {
   ETHEREUM: '0x1',
   GOERLI: '0x5',

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,9 @@ export type SmartTransactionsStatus = {
   minedHash: string;
   minedTx: SmartTransactionMinedTx;
   isSettled: boolean;
+  duplicated?: boolean;
+  timedOut?: boolean;
+  proxied?: boolean;
 };
 
 export type SmartTransaction = {


### PR DESCRIPTION
## Description
This PR does a few things:
- Updates a domain name from `https://transaction.metaswap.codefi.network` to `https://transaction.api.cx.metamask.io`
- Adds new props on the `SmartTransactionsStatus` type
- Adds a new function `getSmartTransactionByMinedTxHash`
