### PR TITLE
Emit an event with a Smart Transaction before confirmation

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -394,6 +394,13 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       return;
     }
 
+    // We have to emit this event here, because then a txHash is returned to the TransactionController once it's available
+    // and the #doesTransactionNeedConfirmation function will work properly, since it will find the txHash in the regular transactions list.
+    this.eventEmitter.emit(
+      `${smartTransaction.uuid}:smartTransaction`,
+      smartTransaction,
+    );
+
     if (
       (smartTransaction.status === SmartTransactionStatuses.SUCCESS ||
         smartTransaction.status === SmartTransactionStatuses.REVERTED) &&
@@ -426,11 +433,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
         },
       });
     }
-
-    this.eventEmitter.emit(
-      `${smartTransaction.uuid}:smartTransaction`,
-      smartTransaction,
-    );
   }
 
   async updateSmartTransactions({


### PR DESCRIPTION
## Description
We have to emit an event with an updated Smart Transaction first before confirmation, because then a txHash is returned to the TransactionController once it's available and the `#doesTransactionNeedConfirmation` function will work properly, since it will find the txHash in the regular transactions list.

## Testing Steps
- Opt into Smart Transactions
- Submit a Send transaction on Sepolia
- Once it's finished, you can check that the `Transaction Finalized` event is only triggered once