### PR TITLE
fix: Call the "poll" function only once on a network switch

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -245,10 +245,10 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
     if (!supportedChainIds.includes(chainId)) {
       return;
     }
-    await safelyExecute(async () => this.updateSmartTransactions());
     this.timeoutHandle = setInterval(() => {
       safelyExecute(async () => this.updateSmartTransactions());
     }, this.config.interval);
+    await safelyExecute(async () => this.updateSmartTransactions());
   }
 
   async stop() {


### PR DESCRIPTION
## Description
When a user switched a network and came back, the `poll` function was called multiple times. Now it's only called once.

## Test Steps
1. Submit a Send transaction on Sepolia testnet
2. Switch to Ethereum mainnet when your transaction from 1. is pending
3. After a minute switch back to Sepolia
4. The `/batchStatus` network call is only done once and the `STX Confirmed` event is only trigged once
