### PR TITLE
Save new event props to a newly created smart transaction, use both `properties` and `sensitiveProperties` for events

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -413,6 +413,13 @@ describe('SmartTransactionsController', () => {
             throw new Error('Invalid network client id');
         }
       }),
+      getMetaMetricsProps: jest.fn(async () => {
+        return Promise.resolve({
+          accountHardwareType: 'Ledger Hardware',
+          accountType: 'hardware',
+          deviceModel: 'ledger',
+        });
+      }),
     });
     // eslint-disable-next-line jest/prefer-spy-on
     smartTransactionsController.subscribe = jest.fn();
@@ -761,17 +768,22 @@ describe('SmartTransactionsController', () => {
           `/networks/${ethereumChainIdDec}/submitTransactions?stxControllerVersion=${packageJson.version}`,
         )
         .reply(200, submitTransactionsApiResponse);
-
       await smartTransactionsController.submitSignedTransactions({
         signedTransactions: [signedTransaction],
         signedCanceledTransactions: [signedCanceledTransaction],
         txParams: createTxParams(),
       });
-
-      expect(
+      const submittedSmartTransaction =
         smartTransactionsController.state.smartTransactionsState
-          .smartTransactions[ChainId.mainnet][0].uuid,
-      ).toBe('dP23W7c2kt4FK9TmXOkz1UM2F20');
+          .smartTransactions[ChainId.mainnet][0];
+      expect(submittedSmartTransaction.uuid).toBe(
+        'dP23W7c2kt4FK9TmXOkz1UM2F20',
+      );
+      expect(submittedSmartTransaction.accountHardwareType).toBe(
+        'Ledger Hardware',
+      );
+      expect(submittedSmartTransaction.accountType).toBe('hardware');
+      expect(submittedSmartTransaction.deviceModel).toBe('ledger');
     });
   });
 

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -42,6 +42,7 @@ import {
   snapshotFromTxMeta,
   getTxHash,
   getSmartTransactionMetricsProperties,
+  getSmartTransactionMetricsSensitiveProperties,
 } from './utils';
 
 const SECOND = 1000;
@@ -316,7 +317,9 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
     this.trackMetaMetricsEvent({
       event: MetaMetricsEventName.StxStatusUpdated,
       category: MetaMetricsEventCategory.Transactions,
-      properties: getSmartTransactionMetricsProperties(updatedSmartTransaction),
+      properties: getSmartTransactionMetricsProperties(smartTransaction),
+      sensitiveProperties:
+        getSmartTransactionMetricsSensitiveProperties(smartTransaction),
     });
   }
 
@@ -588,6 +591,8 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
           event: MetaMetricsEventName.StxConfirmed,
           category: MetaMetricsEventCategory.Transactions,
           properties: getSmartTransactionMetricsProperties(smartTransaction),
+          sensitiveProperties:
+            getSmartTransactionMetricsSensitiveProperties(smartTransaction),
         });
         this.#updateSmartTransaction(
           { ...smartTransaction, confirmed: true },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,9 @@ describe('default export', () => {
       getTransactions: jest.fn(),
       trackMetaMetricsEvent: jest.fn(),
       getNetworkClientById: jest.fn(),
+      getMetaMetricsProps: jest.fn(async () => {
+        return Promise.resolve({});
+      }),
     });
     expect(controller).toBeInstanceOf(SmartTransactionsController);
     jest.clearAllTimers();

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,9 @@ export type SmartTransaction = {
   type?: string;
   confirmed?: boolean;
   cancellable?: boolean;
+  accountHardwareType?: string;
+  accountType?: string;
+  deviceModel?: string;
 };
 
 export type Fee = {
@@ -130,4 +133,10 @@ export type GetTransactionsOptions = {
   initialList?: TransactionMeta[];
   filterToCurrentNetwork?: boolean;
   limit?: number;
+};
+
+export type MetaMetricsProps = {
+  accountHardwareType?: string;
+  accountType?: string;
+  deviceModel?: string;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,5 +258,8 @@ export const getSmartTransactionMetricsSensitiveProperties = (
   return {
     token_from_symbol: smartTransaction.sourceTokenSymbol,
     token_to_symbol: smartTransaction.destinationTokenSymbol,
+    account_hardware_type: smartTransaction.accountHardwareType,
+    account_type: smartTransaction.accountType,
+    device_model: smartTransaction.deviceModel,
   };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,8 +237,6 @@ export const getSmartTransactionMetricsProperties = (
   const smartTransactionStatusMetadata = smartTransaction.statusMetadata;
   return {
     stx_status: smartTransaction.status,
-    token_from_symbol: smartTransaction.sourceTokenSymbol,
-    token_to_symbol: smartTransaction.destinationTokenSymbol,
     type: smartTransaction.type,
     processing_time: getStxProcessingTime(smartTransaction.time),
     is_smart_transaction: true,
@@ -248,5 +246,17 @@ export const getSmartTransactionMetricsProperties = (
     stx_duplicated: smartTransactionStatusMetadata?.duplicated,
     stx_timed_out: smartTransactionStatusMetadata?.timedOut,
     stx_proxied: smartTransactionStatusMetadata?.proxied,
+  };
+};
+
+export const getSmartTransactionMetricsSensitiveProperties = (
+  smartTransaction: SmartTransaction,
+) => {
+  if (!smartTransaction) {
+    return {};
+  }
+  return {
+    token_from_symbol: smartTransaction.sourceTokenSymbol,
+    token_to_symbol: smartTransaction.destinationTokenSymbol,
   };
 };


### PR DESCRIPTION
## Description
Save new event props to a newly created smart transaction, so they can be used in anonymised metrics (only if a user opted into them).