### PR TITLE
fix issue where this.ethQuery is sometimes unexpectedly undefined

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -196,12 +196,12 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       } = this.getNetworkClientById(selectedNetworkClientId);
       const isNewChainId = chainId !== this.config.chainId;
       this.configure({ chainId });
+      this.ethQuery = new EthQuery(provider);
       this.initializeSmartTransactionsForChainId();
       if (isNewChainId) {
         this.#ensureUniqueSmartTransactions();
       }
       this.checkPoll(this.state);
-      this.ethQuery = new EthQuery(provider);
     });
 
     this.subscribe((currentState: any) => this.checkPoll(currentState));


### PR DESCRIPTION
Fix an issue where `this.ethQuery` is sometimes unexpectedly undefined because of initialization sequencing in `onNetworkStateChange` callback. This can lead to an error thrown and failed status updates on pending smart transactions

* Fixes https://metamask.sentry.io/issues/5659814553/?environment=production&project=273505&query=firstRelease%3A12.0.0&referrer=issue-stream&sort=freq&statsPeriod=90d&stream_index=9


