### PR TITLE
chore: Use a new API for a health check

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -13,7 +13,9 @@ import {
 import nock from 'nock';
 import * as sinon from 'sinon';
 
-import { API_BASE_URL } from './constants';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { API_BASE_URL, SENTINEL_API_BASE_URL_MAP } from './constants';
 import SmartTransactionsController, {
   DEFAULT_INTERVAL,
   getDefaultSmartTransactionsControllerState,
@@ -279,7 +281,7 @@ const createStateAfterSuccess = () => {
 };
 
 const createSuccessLivenessApiResponse = () => ({
-  lastBlock: 123456,
+  smartTransactions: true,
 });
 
 const testHistory = [
@@ -830,8 +832,8 @@ describe('SmartTransactionsController', () => {
     it('fetches a liveness for Smart Transactions API', async () => {
       await withController(async ({ controller }) => {
         const successLivenessApiResponse = createSuccessLivenessApiResponse();
-        nock(API_BASE_URL)
-          .get(`/networks/${ethereumChainIdDec}/health`)
+        nock(SENTINEL_API_BASE_URL_MAP[ethereumChainIdDec])
+          .get(`/network`)
           .reply(200, successLivenessApiResponse);
 
         const liveness = await controller.fetchLiveness();
@@ -842,8 +844,8 @@ describe('SmartTransactionsController', () => {
 
     it('fetches liveness and sets in feesByChainId state for the Smart Transactions API for the chainId of the networkClientId passed in', async () => {
       await withController(async ({ controller }) => {
-        nock(API_BASE_URL)
-          .get(`/networks/${sepoliaChainIdDec}/health`)
+        nock(SENTINEL_API_BASE_URL_MAP[sepoliaChainIdDec])
+          .get(`/network`)
           .replyWithError('random error');
 
         expect(

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -947,7 +947,7 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       const response = await this.#fetch(
         getAPIRequestURL(APIType.LIVENESS, chainId),
       );
-      liveness = Boolean(response.lastBlock);
+      liveness = Boolean(response.smartTransactions);
     } catch (error) {
       console.log('"fetchLiveness" API call failed');
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,15 @@
 export const API_BASE_URL = 'https://transaction.api.cx.metamask.io';
 
+type SentinelApiBaseUrlMap = {
+  [key: number]: string;
+};
+
+// The map with types applied
+export const SENTINEL_API_BASE_URL_MAP: SentinelApiBaseUrlMap = {
+  1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
+  11155111: 'https://tx-sentinel-ethereum-sepolia.api.cx.metamask.io',
+};
+
 export enum MetaMetricsEventName {
   StxStatusUpdated = 'STX Status Updated',
   StxConfirmed = 'STX Confirmed',

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@metamask/controller-utils';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { API_BASE_URL } from './constants';
+import { API_BASE_URL, SENTINEL_API_BASE_URL_MAP } from './constants';
 import {
   SmartTransactionMinedTx,
   APIType,
@@ -72,7 +72,7 @@ describe('src/utils.js', () => {
 
     it('returns a URL for smart transactions API liveness', () => {
       expect(utils.getAPIRequestURL(APIType.LIVENESS, ChainId.mainnet)).toBe(
-        `${API_BASE_URL}/networks/${ethereumChainIdDec}/health`,
+        `${SENTINEL_API_BASE_URL_MAP[ethereumChainIdDec]}/network`,
       );
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import jsonDiffer from 'fast-json-patch';
 import _ from 'lodash';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-import { API_BASE_URL } from './constants';
+import { API_BASE_URL, SENTINEL_API_BASE_URL_MAP } from './constants';
 import type { SmartTransaction, SmartTransactionsStatus } from './types';
 import {
   APIType,
@@ -52,7 +52,7 @@ export function getAPIRequestURL(apiType: APIType, chainId: string): string {
     }
 
     case APIType.LIVENESS: {
-      return `${API_BASE_URL}/networks/${chainIdDec}/health`;
+      return `${SENTINEL_API_BASE_URL_MAP[chainIdDec]}/network`;
     }
 
     default: {


### PR DESCRIPTION
## Description
We want to stop using transaction-api and use Sentinel instead. This is the first step in that journey: migrating the health API checkpoint.