### PR TITLE
Emit a new "smartTransactionConfirmationDone" event

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -149,12 +149,18 @@ export type SmartTransactionsControllerSmartTransactionEvent = {
   payload: [SmartTransaction];
 };
 
+export type SmartTransactionsControllerSmartTransactionConfirmationDoneEvent = {
+  type: 'SmartTransactionsController:smartTransactionConfirmationDone';
+  payload: [SmartTransaction];
+};
+
 /**
  * The events that {@link SmartTransactionsController} can emit.
  */
 export type SmartTransactionsControllerEvents =
   | SmartTransactionsControllerStateChangeEvent
-  | SmartTransactionsControllerSmartTransactionEvent;
+  | SmartTransactionsControllerSmartTransactionEvent
+  | SmartTransactionsControllerSmartTransactionConfirmationDoneEvent;
 
 export type AllowedEvents = NetworkControllerStateChangeEvent;
 
@@ -682,6 +688,11 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
         category: MetaMetricsEventCategory.Transactions,
       });
       console.error('confirm error', error);
+    } finally {
+      this.messagingSystem.publish(
+        `SmartTransactionsController:smartTransactionConfirmationDone`,
+        smartTransaction,
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export type {
   SmartTransactionsControllerActions,
   SmartTransactionsControllerStateChangeEvent,
   SmartTransactionsControllerSmartTransactionEvent,
+  SmartTransactionsControllerSmartTransactionConfirmationDoneEvent,
   SmartTransactionsControllerEvents,
 } from './SmartTransactionsController';


### PR DESCRIPTION
## Description
Emit a new "smartTransactionConfirmationDone" event, which can be used in the extension and mobile.