### PR TITLE
Standardize tsconfig files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,10 +25,6 @@ module.exports = {
 
     {
       files: ['*.test.ts', '*.test.js'],
-      parserOptions: {
-        project: ['./tsconfig.test.json'],
-        tsconfigRootDir: __dirname,
-      },
       extends: ['@metamask/eslint-config-jest'],
     },
   ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc --project .",
+    "build": "tsc --project tsconfig.build.json",
     "build:clean": "rm -rf dist && yarn build",
     "build:link": "yarn build && cd dist && yarn link && rm -rf node_modules && cd ..",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "inlineSources": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": [
+    "./src/**/__fixtures__/**/*",
+    "./src/**/__mocks__/**/*",
+    "./src/**/__test__/**/*",
+    "./src/**/__tests__/**/*",
+    "./src/**/__snapshots__/**/*",
+    "./src/**/*.test.ts",
+    "./src/**/*.test-d.ts",
+    "./src/**/*.test.*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,14 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "inlineSources": true,
     "lib": ["DOM", "ES2020"],
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "strict": true,
-    "target": "ES2017",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "strict": true,
+    "target": "es2017"
   },
-  "exclude": ["./src/**/*.test.ts"],
-  "include": ["./src/**/*.ts"]
+  "exclude": ["./dist", "**/node_modules"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["./src/**/*.test.ts"],
-  "exclude": []
-}


### PR DESCRIPTION
This project has two kinds of TypeScript config files, which is consistent with the module template. However, whereas in the module template, the default config file (`tsconfig.json`) is the one used for development and `tsconfig.build.json` is used to build the project, in this repo it's reversed (`tsconfig.test.json` used for development).

This commit aligns the kinds of TypeScript configuration files with the module template. It also normalizes the existing options to fit the module template. There should be no differences to `dist/`.