### PR TITLE
Fix tsconfig to emit JS files in addition to declarations

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "emitDeclarationOnly": true,
     "inlineSources": true,
     "noEmit": false,
     "outDir": "dist",


### PR DESCRIPTION
`tsconfig.build.json` is now instructing TypeScript to only emit type declaration files instead of also emitting JavaScript files. This change was erroneously made in a previous commit. This commit removes that instruction.

## Manual Testing

- Run `yarn build`
- Inspect `dist/`. You should see `.js` and `.js.map` files in addition to `.d.ts` files.