### PR TITLE
chore: Remove unnecessary `events` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/polling-controller": "^12.0.0",
     "bignumber.js": "^9.0.1",
-    "events": "^3.3.0",
     "fast-json-patch": "^3.1.0",
     "lodash": "^4.17.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,7 +1678,6 @@ __metadata:
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
-    events: ^3.3.0
     fast-json-patch: ^3.1.0
     isomorphic-fetch: ^3.0.0
     jest: ^29.7.0
@@ -4009,13 +4008,6 @@ __metadata:
   version: 0.2.1
   resolution: "ethjs-schema@npm:0.2.1"
   checksum: 7d8b1225bcf9616bfe94a24c2f4a48dae5ec30180a61d509efd7335eec68431abee638fbd02c2088e0ee59010396284e4b8364af8afdb229ac67e29ae38a3230
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This dependency was not used anywhere. Previously it was brought in because an older version of this controller extended `EventEmitter`, but even then the package wasn't really used (the Node.js events module was resolved instead).

We're not even using `EventEmitter` anymore since the migration to the `BaseControllerV2` base class.
