### PR TITLE
chore: Update `@metamask/transaction-controller` peer dependency to `42.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING** Update `@metamask/transaction-controller` peer dependency from `^38.0.0` to `^42.0.0` ([#482](https://github.com/MetaMask/smart-transactions-controller/pull/482))
 
+### REMOVED
+- **BREAKING** Remove exports for `AllowedActions` and `AllowedEvents` types ([#482](https://github.com/MetaMask/smart-transactions-controller/pull/482))
+
 ## [15.1.0]
 ### Changed
 - Update constants.ts to add a BSC url for smart transactions ([#483](https://github.com/MetaMask/smart-transactions-controller/pull/483))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING** Update `@metamask/transaction-controller` peer dependency from `^38.0.0` to `^42.0.0` ([#482](https://github.com/MetaMask/smart-transactions-controller/pull/482))
 
-### REMOVED
+### Removed
 - **BREAKING** Remove exports for `AllowedActions` and `AllowedEvents` types ([#482](https://github.com/MetaMask/smart-transactions-controller/pull/482))
 
 ## [15.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING** Update `@metamask/transaction-controller` peer dependency from `^38.0.0` to `^42.0.0` ([#482](https://github.com/MetaMask/smart-transactions-controller/pull/482))
 
 ## [15.0.0]
 ### Changed

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@metamask/gas-fee-controller": "^22.0.0",
     "@metamask/json-rpc-engine": "^10.0.1",
     "@metamask/network-controller": "^22.0.0",
-    "@metamask/transaction-controller": "^38.0.0",
+    "@metamask/transaction-controller": "^42.0.0",
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.194",
     "@types/node": "^18.19.17",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@metamask/network-controller": "^22.0.0",
-    "@metamask/transaction-controller": "^38.0.0"
+    "@metamask/transaction-controller": "^42.0.0"
   },
   "peerDependenciesMeta": {
     "@metamask/accounts-controller": {

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -5,6 +5,9 @@ import {
   ChainId,
 } from '@metamask/controller-utils';
 import {
+  type NetworkControllerGetNetworkClientByIdAction,
+  type NetworkControllerGetStateAction,
+  type NetworkControllerStateChangeEvent,
   NetworkStatus,
   RpcEndpointType,
   type NetworkState,
@@ -25,8 +28,6 @@ import SmartTransactionsController, {
   getDefaultSmartTransactionsControllerState,
 } from './SmartTransactionsController';
 import type {
-  AllowedActions,
-  AllowedEvents,
   SmartTransactionsControllerActions,
   SmartTransactionsControllerEvents,
 } from './SmartTransactionsController';
@@ -1237,6 +1238,7 @@ describe('SmartTransactionsController', () => {
                 txParams: {
                   from: '0x123',
                 },
+                networkClientId: NetworkType.mainnet,
               },
             ],
             state: {
@@ -1267,6 +1269,7 @@ describe('SmartTransactionsController', () => {
               txParams: {
                 from: '0x123',
               },
+              networkClientId: NetworkType.mainnet,
             },
             'Smart transaction cancelled',
           );
@@ -1294,6 +1297,7 @@ describe('SmartTransactionsController', () => {
                 txParams: {
                   from: '0x123',
                 },
+                networkClientId: NetworkType.mainnet,
               },
             ],
           },
@@ -1361,6 +1365,7 @@ describe('SmartTransactionsController', () => {
                 txParams: {
                   from: '0x123',
                 },
+                networkClientId: NetworkType.mainnet,
               },
             ],
           },
@@ -1942,8 +1947,10 @@ async function withController<ReturnValue>(
   const [{ ...rest }, fn] = args.length === 2 ? args : [{}, args[0]];
   const { options } = rest;
   const controllerMessenger = new ControllerMessenger<
-    SmartTransactionsControllerActions | AllowedActions,
-    SmartTransactionsControllerEvents | AllowedEvents
+    | SmartTransactionsControllerActions
+    | NetworkControllerGetNetworkClientByIdAction
+    | NetworkControllerGetStateAction,
+    SmartTransactionsControllerEvents | NetworkControllerStateChangeEvent
   >();
   controllerMessenger.registerActionHandler(
     'NetworkController:getNetworkClientById',
@@ -1969,9 +1976,19 @@ async function withController<ReturnValue>(
     }),
   );
 
+  controllerMessenger.registerActionHandler(
+    'NetworkController:getState',
+    jest.fn().mockReturnValue({
+      selectedNetworkClientId: NetworkType.mainnet,
+    }),
+  );
+
   const messenger = controllerMessenger.getRestricted({
     name: 'SmartTransactionsController',
-    allowedActions: ['NetworkController:getNetworkClientById'],
+    allowedActions: [
+      'NetworkController:getNetworkClientById',
+      'NetworkController:getState',
+    ],
     allowedEvents: ['NetworkController:stateChange'],
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,21 +1,25 @@
 import { ControllerMessenger } from '@metamask/base-controller';
+import {
+  type NetworkControllerGetNetworkClientByIdAction,
+  type NetworkControllerGetStateAction,
+  type NetworkControllerStateChangeEvent,
+} from '@metamask/network-controller';
 
 import DefaultExport, {
   type SmartTransactionsControllerActions,
   type SmartTransactionsControllerEvents,
 } from '.';
-import SmartTransactionsController, {
-  type AllowedActions,
-  type AllowedEvents,
-} from './SmartTransactionsController';
+import SmartTransactionsController from './SmartTransactionsController';
 import { ClientId } from './types';
 
 describe('default export', () => {
   it('exports SmartTransactionsController', () => {
     jest.useFakeTimers();
     const controllerMessenger = new ControllerMessenger<
-      SmartTransactionsControllerActions | AllowedActions,
-      SmartTransactionsControllerEvents | AllowedEvents
+      | SmartTransactionsControllerActions
+      | NetworkControllerGetNetworkClientByIdAction
+      | NetworkControllerGetStateAction,
+      SmartTransactionsControllerEvents | NetworkControllerStateChangeEvent
     >();
     const messenger = controllerMessenger.getRestricted({
       name: 'SmartTransactionsController',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { NetworkClientId } from '@metamask/network-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
 /** API */
@@ -103,6 +104,7 @@ export type SmartTransaction = {
   accountType?: string;
   deviceModel?: string;
   transactionId?: string; // It's an ID for a regular transaction from the TransactionController.
+  networkClientId?: NetworkClientId;
 };
 
 export type Fee = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,9 +1284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.4.2, @metamask/controller-utils@npm:^11.4.3":
-  version: 11.4.3
-  resolution: "@metamask/controller-utils@npm:11.4.3"
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.4.2, @metamask/controller-utils@npm:^11.4.3, @metamask/controller-utils@npm:^11.4.4":
+  version: 11.4.4
+  resolution: "@metamask/controller-utils@npm:11.4.4"
   dependencies:
     "@ethereumjs/util": ^8.1.0
     "@metamask/eth-query": ^4.0.0
@@ -1298,7 +1298,9 @@ __metadata:
     bn.js: ^5.2.1
     eth-ens-namehash: ^2.0.8
     fast-deep-equal: ^3.1.3
-  checksum: 610f2e5444b79bca3d049c04c5c6dfb4331e199c601f4e0c808e33a7aec4b76a015e97b5a6a2e6666669d2be2b586acf1edb82edd58f6b849c9d8a253345f9a3
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+  checksum: 1f25521a31b0fad7567a2186ee37acb95d7ef2560c1244cf1cb7ed4b61868ffe35719dba0ac7194f47d787b46fe345bd2fb577b178e4683fa252222f0ee09e7b
   languageName: node
   linkType: hard
 
@@ -1352,16 +1354,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^11.0.1, @metamask/eth-block-tracker@npm:^11.0.2":
-  version: 11.0.2
-  resolution: "@metamask/eth-block-tracker@npm:11.0.2"
+"@metamask/eth-block-tracker@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "@metamask/eth-block-tracker@npm:11.0.3"
   dependencies:
     "@metamask/eth-json-rpc-provider": ^4.1.5
     "@metamask/safe-event-emitter": ^3.1.1
     "@metamask/utils": ^9.1.0
     json-rpc-random-id: ^1.0.1
     pify: ^5.0.0
-  checksum: 3a8a2474c8377a6af0c0fd9d0dea15dbba0c0f5794ace883804d5b467787d2411158867fa3fc810da7749b274df5b0bd6fd80282ff3128b5b334152a742fa111
+  checksum: e1c9673ccc36c14558ebecd8617d9ed704c77e5a3c5ef604c320a8ec56087307dd21651802d0892d1e1e567c82bd1748a7454dbb54099cab25db15f045bd797c
   languageName: node
   linkType: hard
 
@@ -1377,11 +1379,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@metamask/eth-json-rpc-middleware@npm:15.0.0"
+"@metamask/eth-json-rpc-middleware@npm:^15.0.1":
+  version: 15.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:15.0.1"
   dependencies:
-    "@metamask/eth-block-tracker": ^11.0.1
+    "@metamask/eth-block-tracker": ^11.0.3
     "@metamask/eth-json-rpc-provider": ^4.1.5
     "@metamask/eth-sig-util": ^7.0.3
     "@metamask/json-rpc-engine": ^10.0.0
@@ -1392,7 +1394,7 @@ __metadata:
     klona: ^2.0.6
     pify: ^5.0.0
     safe-stable-stringify: ^2.4.3
-  checksum: d7ffdb9e2f322bdf584daffb5f788faa97f8d80e97f41462471ef629f2d40f6d9c95423f5fd8522c5622f881019e3d5c08ca4ee382e9aff26da9fef144353540
+  checksum: 05da025f7c436cf3f65fc4afa0050c0360bb237dd24df85c654225e6bab5e9e86697e67714d6bb80a5c1d6b0268a47d8997f082cd31c2bacb4f7005a924e98fc
   languageName: node
   linkType: hard
 
@@ -1560,27 +1562,28 @@ __metadata:
   linkType: hard
 
 "@metamask/network-controller@npm:^22.0.0":
-  version: 22.0.2
-  resolution: "@metamask/network-controller@npm:22.0.2"
+  version: 22.1.1
+  resolution: "@metamask/network-controller@npm:22.1.1"
   dependencies:
     "@metamask/base-controller": ^7.0.2
-    "@metamask/controller-utils": ^11.4.3
-    "@metamask/eth-block-tracker": ^11.0.2
+    "@metamask/controller-utils": ^11.4.4
+    "@metamask/eth-block-tracker": ^11.0.3
     "@metamask/eth-json-rpc-infura": ^10.0.0
-    "@metamask/eth-json-rpc-middleware": ^15.0.0
+    "@metamask/eth-json-rpc-middleware": ^15.0.1
     "@metamask/eth-json-rpc-provider": ^4.1.6
     "@metamask/eth-query": ^4.0.0
     "@metamask/json-rpc-engine": ^10.0.1
     "@metamask/rpc-errors": ^7.0.1
-    "@metamask/swappable-obj-proxy": ^2.2.0
+    "@metamask/swappable-obj-proxy": ^2.3.0
     "@metamask/utils": ^10.0.0
     async-mutex: ^0.5.0
+    fast-deep-equal: ^3.1.3
     immer: ^9.0.6
     loglevel: ^1.8.1
     reselect: ^5.1.1
     uri-js: ^4.4.1
     uuid: ^8.3.2
-  checksum: 94ec3adcf8a7e27a42f7e836753a1a9c0a423a383222e3e83b89f461f597b5218105673f82ca9fd4ad75079432b42b969d640ea810bec34a6026b28fa540e04c
+  checksum: 76faf858590fdc7d8af36e4cff7128440cb80442e2d4fea057e6c0ef730837864e6ceb881b9b798df473e3bb0c99cc76d6a95d23766ec04dde73df43e18d8c2c
   languageName: node
   linkType: hard
 
@@ -1662,7 +1665,7 @@ __metadata:
     "@metamask/json-rpc-engine": ^10.0.1
     "@metamask/network-controller": ^22.0.0
     "@metamask/polling-controller": ^12.0.0
-    "@metamask/transaction-controller": ^38.0.0
+    "@metamask/transaction-controller": ^42.0.0
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
     "@types/node": ^18.19.17
@@ -1690,7 +1693,7 @@ __metadata:
     typescript: ~4.8.4
   peerDependencies:
     "@metamask/network-controller": ^22.0.0
-    "@metamask/transaction-controller": ^38.0.0
+    "@metamask/transaction-controller": ^42.0.0
   peerDependenciesMeta:
     "@metamask/accounts-controller":
       optional: true
@@ -1706,16 +1709,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/swappable-obj-proxy@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@metamask/swappable-obj-proxy@npm:2.2.0"
-  checksum: 343c95f72c96776980ef3e70600f7fa312be9a75683c132404a66ddd3c507abadee9c4deba1385246f73bded1938a7958e5a89fc407c19dfc352dd9b398e216f
+"@metamask/swappable-obj-proxy@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@metamask/swappable-obj-proxy@npm:2.3.0"
+  checksum: 6fdf0f2d93406b472dd260b3851b5f92704561e0ab94f75fccc9525b69eb361cd915caabac58cf529e747088d36860d6c9c1cd8d0d85d04a3af924ffe6ca4f9e
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^38.0.0":
-  version: 38.3.0
-  resolution: "@metamask/transaction-controller@npm:38.3.0"
+"@metamask/transaction-controller@npm:^42.0.0":
+  version: 42.0.0
+  resolution: "@metamask/transaction-controller@npm:42.0.0"
   dependencies:
     "@ethereumjs/common": ^3.2.0
     "@ethereumjs/tx": ^4.2.0
@@ -1724,7 +1727,7 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/base-controller": ^7.0.2
-    "@metamask/controller-utils": ^11.4.2
+    "@metamask/controller-utils": ^11.4.4
     "@metamask/eth-query": ^4.0.0
     "@metamask/metamask-eth-abis": ^3.1.1
     "@metamask/nonce-tracker": ^6.0.0
@@ -1737,12 +1740,13 @@ __metadata:
     lodash: ^4.17.21
     uuid: ^8.3.2
   peerDependencies:
-    "@babel/runtime": ^7.23.9
-    "@metamask/accounts-controller": ^18.0.0
+    "@babel/runtime": ^7.0.0
+    "@metamask/accounts-controller": ^20.0.0
     "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
     "@metamask/gas-fee-controller": ^22.0.0
     "@metamask/network-controller": ^22.0.0
-  checksum: 81cb06947d833c04f35d7e987d4606a45a1a0b985b244c70c1896370a17264bcc4d802dd38d2a56fae36ce162303e050fc04094ec85cbfb9d44b4621f4237041
+  checksum: 836a198601d4221aaa62994caa2253274b32f9caabe35a5e7daea07f383288f60dce41bb7f2f197eea5be94b31e78fb9979d6d0338242d0f79c44c488249bbbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update `@metamask/transaction-controller` peer dependency from `38.0.0` to `42.0.0`

Breaking changes introduced in version `41.0.0` of `@metamask/transaction-controller` affect `@metamask/smart-transactions-controller`. These changes involve the removal of global network usage, requiring the explicit configuration of `networkClientId`. [CHANGELOG](https://github.com/MetaMask/core/blob/main/packages/transaction-controller/CHANGELOG.md?plain=1#L71)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
