### PR TITLE
fix: Extend definition of when a regular tx is marked as failed, clean up unsupported statuses

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1270,8 +1270,12 @@ describe('SmartTransactionsController', () => {
                 from: '0x123',
               },
               networkClientId: NetworkType.mainnet,
+              error: {
+                message: 'Smart transaction failed with status: cancelled',
+                name: 'SmartTransactionFailed',
+              },
             },
-            'Smart transaction cancelled',
+            'Smart transaction status: cancelled',
           );
         },
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,12 +36,7 @@ export enum SmartTransactionStatuses {
   REVERTED = 'reverted',
   UNKNOWN = 'unknown',
   CANCELLED = 'cancelled',
-  CANCELLED_WOULD_REVERT = 'cancelled_would_revert',
-  CANCELLED_TOO_CHEAP = 'cancelled_too_cheap',
-  CANCELLED_DEADLINE_MISSED = 'cancelled_deadline_missed',
-  CANCELLED_INVALID_NONCE = 'cancelled_invalid_nonce',
   CANCELLED_USER_CANCELLED = 'cancelled_user_cancelled',
-  CANCELLED_PREVIOUS_TX_CANCELLED = 'cancelled_previous_tx_cancelled',
   RESOLVED = 'resolved',
 }
 
@@ -52,17 +47,17 @@ export enum ClientId {
 
 export const cancellationReasonToStatusMap = {
   [SmartTransactionCancellationReason.WOULD_REVERT]:
-    SmartTransactionStatuses.CANCELLED_WOULD_REVERT,
+    SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.TOO_CHEAP]:
-    SmartTransactionStatuses.CANCELLED_TOO_CHEAP,
+    SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.DEADLINE_MISSED]:
-    SmartTransactionStatuses.CANCELLED_DEADLINE_MISSED,
+    SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.INVALID_NONCE]:
-    SmartTransactionStatuses.CANCELLED_INVALID_NONCE,
+    SmartTransactionStatuses.CANCELLED,
+  [SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED]:
+    SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.USER_CANCELLED]:
     SmartTransactionStatuses.CANCELLED_USER_CANCELLED,
-  [SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED]:
-    SmartTransactionStatuses.CANCELLED_PREVIOUS_TX_CANCELLED,
 };
 
 export type SmartTransactionsStatus = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,6 @@ export enum SmartTransactionCancellationReason {
   INVALID_NONCE = 'invalid_nonce',
   USER_CANCELLED = 'user_cancelled',
   NOT_CANCELLED = 'not_cancelled',
-  PREVIOUS_TX_CANCELLED = 'previous_tx_cancelled',
 }
 
 export enum SmartTransactionStatuses {
@@ -53,8 +52,6 @@ export const cancellationReasonToStatusMap = {
   [SmartTransactionCancellationReason.DEADLINE_MISSED]:
     SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.INVALID_NONCE]:
-    SmartTransactionStatuses.CANCELLED,
-  [SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED]:
     SmartTransactionStatuses.CANCELLED,
   [SmartTransactionCancellationReason.USER_CANCELLED]:
     SmartTransactionStatuses.CANCELLED_USER_CANCELLED,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -242,17 +242,6 @@ describe('src/utils.js', () => {
         SmartTransactionStatuses.PENDING,
       );
     });
-
-    it('returns status "cancelled" if the "previous_tx_cancelled" cancellationReason is provided', () => {
-      const statusResponse = {
-        ...createStatusResponse(),
-        cancellationReason:
-          SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED,
-      };
-      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
-        SmartTransactionStatuses.CANCELLED,
-      );
-    });
   });
 
   describe('getStxProcessingTime', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,8 @@
-import { ChainId } from '@metamask/controller-utils';
+import { ChainId, NetworkType } from '@metamask/controller-utils';
+import {
+  type TransactionMeta,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
 
 import packageJson from '../package.json';
 import { API_BASE_URL, SENTINEL_API_BASE_URL_MAP } from './constants';
@@ -168,17 +172,7 @@ describe('src/utils.js', () => {
       );
     });
 
-    it('returns cancellation state if cancellationReason provided', () => {
-      const statusResponse = {
-        ...createStatusResponse(),
-        cancellationReason: SmartTransactionCancellationReason.USER_CANCELLED,
-      };
-      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
-        SmartTransactionStatuses.CANCELLED_USER_CANCELLED,
-      );
-    });
-
-    it('returns pending if a tx was user cancelled, but is not settled yet', () => {
+    it('returns status "pending" if a tx was user cancelled, but is not settled yet', () => {
       const statusResponse = {
         ...createStatusResponse(),
         cancellationReason: SmartTransactionCancellationReason.USER_CANCELLED,
@@ -189,14 +183,74 @@ describe('src/utils.js', () => {
       );
     });
 
-    it('returns cancellation state "CANCELLED_PREVIOUS_TX_CANCELLED" if cancellationReason provided', () => {
+    it('returns status "cancelled_user_cancelled" if the "user_cancelled" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.USER_CANCELLED,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.CANCELLED_USER_CANCELLED,
+      );
+    });
+
+    it('returns status "cancelled" if the "would_revert" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.WOULD_REVERT,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.CANCELLED,
+      );
+    });
+
+    it('returns status "cancelled" if the "too_cheap" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.TOO_CHEAP,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.CANCELLED,
+      );
+    });
+
+    it('returns status "cancelled" if the "deadline_missed" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.DEADLINE_MISSED,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.CANCELLED,
+      );
+    });
+
+    it('returns status "cancelled" if the "invalid_nonce" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.INVALID_NONCE,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.CANCELLED,
+      );
+    });
+
+    it('returns status "pending" if the "not_cancelled" cancellationReason is provided', () => {
+      const statusResponse = {
+        ...createStatusResponse(),
+        cancellationReason: SmartTransactionCancellationReason.NOT_CANCELLED,
+      };
+      expect(utils.calculateStatus(statusResponse)).toStrictEqual(
+        SmartTransactionStatuses.PENDING,
+      );
+    });
+
+    it('returns status "cancelled" if the "previous_tx_cancelled" cancellationReason is provided', () => {
       const statusResponse = {
         ...createStatusResponse(),
         cancellationReason:
           SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED,
       };
       expect(utils.calculateStatus(statusResponse)).toStrictEqual(
-        SmartTransactionStatuses.CANCELLED_PREVIOUS_TX_CANCELLED,
+        SmartTransactionStatuses.CANCELLED,
       );
     });
   });
@@ -325,6 +379,225 @@ describe('src/utils.js', () => {
         mobileReturnTxHashAsap: true,
       });
       expect(result).toBe(true);
+    });
+  });
+
+  describe('shouldMarkRegularTransactionAsFailed', () => {
+    const createSmartTransaction = (status: SmartTransactionStatuses) => ({
+      uuid: 'test-uuid',
+      status,
+      transactionId: '123',
+      time: 12345,
+      statusMetadata: {
+        cancellationFeeWei: 0,
+        deadlineRatio: 0,
+        minedHash: '',
+        minedTx: SmartTransactionMinedTx.NOT_MINED,
+        isSettled: false,
+      },
+    });
+
+    const mockGetFeatureFlags =
+      (returnTxHashAsap = true) =>
+      () => ({
+        smartTransactions: {
+          extensionReturnTxHashAsap: returnTxHashAsap,
+          mobileReturnTxHashAsap: returnTxHashAsap,
+        },
+      });
+
+    it('returns true for "cancelled" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns true for "cancelled_user_cancelled" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED_USER_CANCELLED,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns true for "unknown" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.UNKNOWN,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns true for "resolved" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.RESOLVED,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false for "pending" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.PENDING,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for "success" status when feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.SUCCESS,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when feature flag is disabled regardless of status', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED,
+        ),
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(false),
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when transactionId is missing', () => {
+      const smartTransaction = {
+        ...createSmartTransaction(SmartTransactionStatuses.CANCELLED),
+        transactionId: undefined,
+      };
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction,
+        clientId: ClientId.Extension,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns true for mobile client when mobile feature flag is enabled', () => {
+      const result = utils.shouldMarkRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED,
+        ),
+        clientId: ClientId.Mobile,
+        getFeatureFlags: mockGetFeatureFlags(true),
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('markRegularTransactionAsFailed', () => {
+    const createSmartTransaction = (status: SmartTransactionStatuses) => ({
+      uuid: 'test-uuid',
+      status,
+      transactionId: '123',
+      time: 12345,
+      statusMetadata: {
+        cancellationFeeWei: 0,
+        deadlineRatio: 0,
+        minedHash: '',
+        minedTx: SmartTransactionMinedTx.NOT_MINED,
+        isSettled: false,
+      },
+    });
+
+    const mockTransaction: TransactionMeta = {
+      chainId: ChainId.mainnet,
+      id: '123',
+      origin: 'test1.com',
+      status: TransactionStatus.submitted,
+      time: 1631714313,
+      txParams: {
+        from: '0x6',
+      },
+      hash: '0x7',
+      rawTx: '0x8',
+      networkClientId: NetworkType.mainnet,
+    };
+
+    it('updates transaction with failed status and error message', () => {
+      const updateTransactionMock = jest.fn();
+
+      utils.markRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED,
+        ),
+        getRegularTransactions: () => [mockTransaction],
+        updateTransaction: updateTransactionMock,
+      });
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        {
+          ...mockTransaction,
+          status: TransactionStatus.failed,
+          error: {
+            name: 'SmartTransactionFailed',
+            message: 'Smart transaction failed with status: cancelled',
+          },
+        },
+        'Smart transaction status: cancelled',
+      );
+    });
+
+    it('throws error if original transaction cannot be found', () => {
+      const updateTransactionMock = jest.fn();
+      const getRegularTransactionsMock = jest.fn(() => []);
+
+      expect(() =>
+        utils.markRegularTransactionAsFailed({
+          smartTransaction: createSmartTransaction(
+            SmartTransactionStatuses.CANCELLED,
+          ),
+          getRegularTransactions: getRegularTransactionsMock,
+          updateTransaction: updateTransactionMock,
+        }),
+      ).toThrow('Cannot find regular transaction to mark it as failed');
+
+      expect(updateTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('does not update transaction if status is already failed', () => {
+      const updateTransactionMock = jest.fn();
+      const failedTransaction = {
+        ...mockTransaction,
+        status: TransactionStatus.failed,
+        error: {
+          name: 'SmartTransactionFailed',
+          message: 'Smart transaction failed',
+        },
+      };
+
+      utils.markRegularTransactionAsFailed({
+        smartTransaction: createSmartTransaction(
+          SmartTransactionStatuses.CANCELLED,
+        ),
+        getRegularTransactions: () => [failedTransaction],
+        updateTransaction: updateTransactionMock,
+      });
+
+      expect(updateTransactionMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,6 @@ export const calculateStatus = (stxStatus: SmartTransactionsStatus) => {
     SmartTransactionCancellationReason.DEADLINE_MISSED,
     SmartTransactionCancellationReason.INVALID_NONCE,
     SmartTransactionCancellationReason.USER_CANCELLED,
-    SmartTransactionCancellationReason.PREVIOUS_TX_CANCELLED,
   ];
   if (stxStatus?.minedTx === SmartTransactionMinedTx.NOT_MINED) {
     if (


### PR DESCRIPTION
## Description
Extends definition of when a regular tx is marked as failed (only if we return a txHash asap) and clean up unsupported statuses.
