### PR TITLE
feat: add Base Sentinel endpoint to STX controller

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ type SentinelApiBaseUrlMap = {
 export const SENTINEL_API_BASE_URL_MAP: SentinelApiBaseUrlMap = {
   1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
   56: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
+  8453: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
   11155111: 'https://tx-sentinel-ethereum-sepolia.api.cx.metamask.io',
 };
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -92,6 +92,16 @@ describe('src/utils.js', () => {
         `${SENTINEL_API_BASE_URL_MAP[ethereumChainIdDec]}/network`,
       );
     });
+
+    // Add our new test case for baseChainId
+    it('returns a URL for smart transactions API liveness on Base', () => {
+      const baseChainIdHex = '0x2105';
+      const baseChainIdDec = parseInt(baseChainIdHex, 16); // update ChainId in @metamask/controller-utils to include baseChainId
+      expect(utils.getAPIRequestURL(APIType.LIVENESS, baseChainIdHex)).toBe(
+        `${SENTINEL_API_BASE_URL_MAP[baseChainIdDec]}/network`,
+      );
+    });
+    // Add test cases for BSC and Ethereum Sepolia?
   });
 
   describe('isSmartTransactionStatusResolved', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -93,7 +93,6 @@ describe('src/utils.js', () => {
       );
     });
 
-    // Add our new test case for baseChainId
     it('returns a URL for smart transactions API liveness on Base', () => {
       const baseChainIdHex = '0x2105';
       const baseChainIdDec = parseInt(baseChainIdHex, 16); // update ChainId in @metamask/controller-utils to include baseChainId
@@ -101,7 +100,6 @@ describe('src/utils.js', () => {
         `${SENTINEL_API_BASE_URL_MAP[baseChainIdDec]}/network`,
       );
     });
-    // Add test cases for BSC and Ethereum Sepolia?
   });
 
   describe('isSmartTransactionStatusResolved', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -46,6 +46,7 @@ describe('src/utils.js', () => {
 
   describe('getAPIRequestURL', () => {
     const ethereumChainIdDec = parseInt(ChainId.mainnet, 16);
+    const ethSepoliaChainIdDec = parseInt(ChainId.sepolia, 16);
 
     it('returns a URL for getting transactions', () => {
       expect(utils.getAPIRequestURL(APIType.GET_FEES, ChainId.mainnet)).toBe(
@@ -93,20 +94,18 @@ describe('src/utils.js', () => {
       );
     });
 
+    it('returns a URL for smart transactions API liveness on ETH Sepolia', () => {
+      expect(utils.getAPIRequestURL(APIType.LIVENESS, ChainId.sepolia)).toBe(
+        `${SENTINEL_API_BASE_URL_MAP[ethSepoliaChainIdDec]}/network`,
+      );
+    });
+
     it('returns a URL for smart transactions API liveness on BSC', () => {
       const bscChainIdHex = '0x38';
       const bscChainIdDec = parseInt(bscChainIdHex, 16);
       expect(utils.getAPIRequestURL(APIType.LIVENESS, bscChainIdHex)).toBe(
         `${SENTINEL_API_BASE_URL_MAP[bscChainIdDec]}/network`,
       );
-    });
-
-    it('returns a URL for smart transactions API liveness on ETH Sepolia', () => {
-      const ethSepoliaChainIdHex = '0xaa36a7';
-      const ethSepoliaChainIdDec = parseInt(ethSepoliaChainIdHex, 16);
-      expect(
-        utils.getAPIRequestURL(APIType.LIVENESS, ethSepoliaChainIdHex),
-      ).toBe(`${SENTINEL_API_BASE_URL_MAP[ethSepoliaChainIdDec]}/network`);
     });
 
     it('returns a URL for smart transactions API liveness on Base', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -95,7 +95,7 @@ describe('src/utils.js', () => {
 
     it('returns a URL for smart transactions API liveness on Base', () => {
       const baseChainIdHex = '0x2105';
-      const baseChainIdDec = parseInt(baseChainIdHex, 16); // update ChainId in @metamask/controller-utils to include baseChainId
+      const baseChainIdDec = parseInt(baseChainIdHex, 16);
       expect(utils.getAPIRequestURL(APIType.LIVENESS, baseChainIdHex)).toBe(
         `${SENTINEL_API_BASE_URL_MAP[baseChainIdDec]}/network`,
       );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -87,10 +87,26 @@ describe('src/utils.js', () => {
       ).toBe(`${API_BASE_URL}/networks/${ethereumChainIdDec}/batchStatus`);
     });
 
-    it('returns a URL for smart transactions API liveness', () => {
+    it('returns a URL for smart transactions API liveness on ETH Mainnet', () => {
       expect(utils.getAPIRequestURL(APIType.LIVENESS, ChainId.mainnet)).toBe(
         `${SENTINEL_API_BASE_URL_MAP[ethereumChainIdDec]}/network`,
       );
+    });
+
+    it('returns a URL for smart transactions API liveness on BSC', () => {
+      const bscChainIdHex = '0x38';
+      const bscChainIdDec = parseInt(bscChainIdHex, 16);
+      expect(utils.getAPIRequestURL(APIType.LIVENESS, bscChainIdHex)).toBe(
+        `${SENTINEL_API_BASE_URL_MAP[bscChainIdDec]}/network`,
+      );
+    });
+
+    it('returns a URL for smart transactions API liveness on ETH Sepolia', () => {
+      const ethSepoliaChainIdHex = '0xaa36a7';
+      const ethSepoliaChainIdDec = parseInt(ethSepoliaChainIdHex, 16);
+      expect(
+        utils.getAPIRequestURL(APIType.LIVENESS, ethSepoliaChainIdHex),
+      ).toBe(`${SENTINEL_API_BASE_URL_MAP[ethSepoliaChainIdDec]}/network`);
     });
 
     it('returns a URL for smart transactions API liveness on Base', () => {


### PR DESCRIPTION
**Description**

This change enables the STX controller to communicate with the Base network's Sentinel API

**What is the current state of things and why does it need to change?**

Currently, the STX controller supports Ethereum Mainnet, BSC, and Ethereum Sepolia networks via the `SENTINEL_API_BASE_URL_MAP` in `constants.ts`. However, there is no support for the Base network, which needs to be added as part of the "STX with auctions on Base" epic.

**What is the solution your changes offer and how does it work?**

This PR adds Base network support to the Smart Transactions Controller by:

Adding the Base chain ID (8453) to the `SENTINEL_API_BASE_URL_MAP` in `constants.ts`

Adding a test case in `utils.test.ts` to verify the Base Sentinel endpoint works correctly

These changes enable the STX controller to communicate with the Base network's Sentinel API, which is first step for implementing "_STX with auctions on Base_".

**Related Issues**
Fixes: TXL-695
