### PR TITLE
feat: Add transaction hash to STX in analytics for opt-in users

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -2225,7 +2225,6 @@ async function withController<ReturnValue>(
     getRemoteFeatureFlags:
       options?.getRemoteFeatureFlags ??
       (() => ({ transactionsTxHashInAnalytics: false })),
-    getParticipateInMetrics: options?.getParticipateInMetrics ?? (() => false),
   });
 
   function triggerNetworStateChange(state: NetworkState) {

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -2222,6 +2222,10 @@ async function withController<ReturnValue>(
     getFeatureFlags: jest.fn(),
     updateTransaction: jest.fn(),
     ...options,
+    getRemoteFeatureFlags:
+      options?.getRemoteFeatureFlags ??
+      (() => ({ transactionsTxHashInAnalytics: false })),
+    getParticipateInMetrics: options?.getParticipateInMetrics ?? (() => false),
   });
 
   function triggerNetworStateChange(state: NetworkState) {

--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -207,7 +207,6 @@ type SmartTransactionsControllerOptions = {
   getFeatureFlags: () => FeatureFlags;
   updateTransaction: (transaction: TransactionMeta, note: string) => void;
   getRemoteFeatureFlags: () => { transactionsTxHashInAnalytics?: boolean };
-  getParticipateInMetrics: () => boolean;
 };
 
 export type SmartTransactionsControllerPollingInput = {
@@ -249,8 +248,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
 
   #getRemoteFeatureFlags: () => { transactionsTxHashInAnalytics?: boolean };
 
-  #getParticipateInMetrics: () => boolean;
-
   /* istanbul ignore next */
   async #fetch(request: string, options?: RequestInit) {
     const fetchOptions = {
@@ -279,7 +276,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
     getFeatureFlags,
     updateTransaction,
     getRemoteFeatureFlags,
-    getParticipateInMetrics,
   }: SmartTransactionsControllerOptions) {
     super({
       name: controllerName,
@@ -328,7 +324,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       (currentState) => this.checkPoll(currentState),
     );
     this.#getRemoteFeatureFlags = getRemoteFeatureFlags;
-    this.#getParticipateInMetrics = getParticipateInMetrics;
   }
 
   async _executePoll({
@@ -422,7 +417,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       sensitiveProperties: getSmartTransactionMetricsSensitiveProperties(
         updatedSmartTransaction,
         this.#getRemoteFeatureFlags,
-        this.#getParticipateInMetrics,
       ),
     });
   }
@@ -748,7 +742,6 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
           sensitiveProperties: getSmartTransactionMetricsSensitiveProperties(
             smartTransaction,
             this.#getRemoteFeatureFlags,
-            this.#getParticipateInMetrics,
           ),
         });
         this.#updateSmartTransaction(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -39,7 +39,6 @@ describe('default export', () => {
       updateTransaction: jest.fn(),
       clientId: ClientId.Extension,
       getRemoteFeatureFlags: () => ({ transactionsTxHashInAnalytics: false }),
-      getParticipateInMetrics: () => false,
     });
     expect(controller).toBeInstanceOf(SmartTransactionsController);
     jest.clearAllTimers();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,8 @@ describe('default export', () => {
       getFeatureFlags: jest.fn(),
       updateTransaction: jest.fn(),
       clientId: ClientId.Extension,
+      getRemoteFeatureFlags: () => ({ transactionsTxHashInAnalytics: false }),
+      getParticipateInMetrics: () => false,
     });
     expect(controller).toBeInstanceOf(SmartTransactionsController);
     jest.clearAllTimers();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,7 +230,7 @@ export const getTxHash = (signedTxHex: any) => {
   }
   const txHashBytes = TransactionFactory.fromSerializedData(
     // eslint-disable-next-line no-restricted-globals
-    Buffer.from(signedTxHex.slice(2), 'hex'),
+    Uint8Array.from(Buffer.from(signedTxHex.slice(2), 'hex')),
   ).hash();
   return bytesToHex(txHashBytes);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,19 +256,43 @@ export const getSmartTransactionMetricsProperties = (
   };
 };
 
+type SmartTransactionSensitiveProperties = {
+  token_from_symbol?: string;
+  token_to_symbol?: string;
+  account_hardware_type?: string;
+  account_type?: string;
+  device_model?: string;
+  transaction_hash?: string;
+};
+
 export const getSmartTransactionMetricsSensitiveProperties = (
   smartTransaction: SmartTransaction,
-) => {
+  getRemoteFeatureFlags?: () => { transactionsTxHashInAnalytics?: boolean },
+  getParticipateInMetrics?: () => boolean,
+): SmartTransactionSensitiveProperties => {
   if (!smartTransaction) {
     return {};
   }
-  return {
+
+  const sensitiveProperties: SmartTransactionSensitiveProperties = {
     token_from_symbol: smartTransaction.sourceTokenSymbol,
     token_to_symbol: smartTransaction.destinationTokenSymbol,
     account_hardware_type: smartTransaction.accountHardwareType,
     account_type: smartTransaction.accountType,
     device_model: smartTransaction.deviceModel,
   };
+
+  // Add transaction hash if feature flag is enabled and user has opted in
+  if (
+    getRemoteFeatureFlags?.()?.transactionsTxHashInAnalytics &&
+    getParticipateInMetrics?.() &&
+    smartTransaction.statusMetadata?.minedHash
+  ) {
+    sensitiveProperties.transaction_hash =
+      smartTransaction.statusMetadata.minedHash;
+  }
+
+  return sensitiveProperties;
 };
 
 export const getReturnTxHashAsap = (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -268,7 +268,6 @@ type SmartTransactionSensitiveProperties = {
 export const getSmartTransactionMetricsSensitiveProperties = (
   smartTransaction: SmartTransaction,
   getRemoteFeatureFlags?: () => { transactionsTxHashInAnalytics?: boolean },
-  getParticipateInMetrics?: () => boolean,
 ): SmartTransactionSensitiveProperties => {
   if (!smartTransaction) {
     return {};
@@ -285,7 +284,6 @@ export const getSmartTransactionMetricsSensitiveProperties = (
   // Add transaction hash if feature flag is enabled and user has opted in
   if (
     getRemoteFeatureFlags?.()?.transactionsTxHashInAnalytics &&
-    getParticipateInMetrics?.() &&
     smartTransaction.statusMetadata?.minedHash
   ) {
     sensitiveProperties.transaction_hash =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { TransactionFactory } from '@ethereumjs/tx';
-import { bytesToHex } from '@ethereumjs/util';
+import { bytesToHex, hexToBytes } from '@ethereumjs/util';
 import { hexlify } from '@ethersproject/bytes';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
@@ -224,13 +224,15 @@ export const incrementNonceInHex = (nonceInHex: string): string => {
   return hexlify(Number(nonceInDec) + 1);
 };
 
-export const getTxHash = (signedTxHex: any) => {
+export const getTxHash = (signedTxHex: string) => {
   if (!signedTxHex) {
     return '';
   }
+  const hexWithoutPrefix = signedTxHex.startsWith('0x')
+    ? signedTxHex.slice(2)
+    : signedTxHex;
   const txHashBytes = TransactionFactory.fromSerializedData(
-    // eslint-disable-next-line no-restricted-globals
-    Uint8Array.from(Buffer.from(signedTxHex.slice(2), 'hex')),
+    hexToBytes(`0x${hexWithoutPrefix}`),
   ).hash();
   return bytesToHex(txHashBytes);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,11 +228,16 @@ export const getTxHash = (signedTxHex: string) => {
   if (!signedTxHex) {
     return '';
   }
-  const hexWithoutPrefix = signedTxHex.startsWith('0x')
-    ? signedTxHex.slice(2)
-    : signedTxHex;
+  // First normalize the entire string to lowercase
+  const normalizedInput = signedTxHex.toLowerCase();
+  // Then remove 0x prefix if it exists
+  const hexWithoutPrefix = normalizedInput.startsWith('0x')
+    ? normalizedInput.slice(2)
+    : normalizedInput;
+  // Add single 0x prefix
+  const prefixedHex = `0x${hexWithoutPrefix}`;
   const txHashBytes = TransactionFactory.fromSerializedData(
-    hexToBytes(`0x${hexWithoutPrefix}`),
+    hexToBytes(prefixedHex),
   ).hash();
   return bytesToHex(txHashBytes);
 };


### PR DESCRIPTION
## Current State and Rationale for Change
Currently, the Smart Transactions (STX) Controller doesn't include transaction hash in analytics events, unlike regular transactions which have been updated to support this functionality. The Data team requires transaction hash in specific transaction events to improve analytics capabilities, and we need to extend this support to Smart Transactions for consistency.

## Solution
This PR extends transaction hash analytics support to Smart Transactions (STX), completing the implementation started in TXL-714:

- Updates the Smart Transactions Controller to support the remote feature flag `transactionsTxHashInAnalytics`
- Adds transaction hash to `sensitiveProperties` in STX analytics events
- Applies the same privacy controls as regular transactions:
  - Only collects hash when users have opted into MetaMetrics
  - Only enables collection when the remote feature flag is active
- Adds proper type definitions for sensitive properties in STX analytics
- Updates tests to support new controller parameters

The implementation extracts transaction hash from the `minedHash` property in the STX status metadata, ensuring consistent behavior with regular transactions.

## Related Links
The corresponding PR in MetaMask Extension is:
https://github.com/MetaMask/metamask-extension/pull/31048

## Manual Testing Steps 

We need to test MetaMask Extension with the changes from this PR for `smart-transactions-controller`.

1. Enable MetaMetrics in wallet settings
2. Set up local override for the remote feature flag in `.manifest-overrides.json`:
```json
{
  "_flags": {
    "remoteFeatureFlags": {
      "transactionsTxHashInAnalytics": {
        "name": "transactionsTxHashInAnalytics",
        "value": true
      }
    }
  }
}
```
3. Perform a Smart Transaction (e.g., a swap that uses STX)
4. Verify through console logs that transaction hash is included in STX analytics events
