### PR TITLE
fix: ensure STX status updates across all networks

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -622,23 +622,24 @@ export default class SmartTransactionsController extends StaticIntervalPollingCo
       if (chainIds && !chainIds.includes(chainId as Hex)) {
         continue;
       }
-      // Filter pending transactions and map them to the desired shape
+
+      // Filter pending transactions for this chainId
       const pendingTransactions = transactions
         .filter(isSmartTransactionPending)
         .map((pendingSmartTransaction) => {
-          // Use the transaction's chainId (from the key) to derive a networkClientId
+          // Use the transaction's chainId to derive a networkClientId
           const networkClientIdToUse = this.#getNetworkClientId({
             chainId: chainId as Hex,
           });
           return {
             uuid: pendingSmartTransaction.uuid,
             networkClientId: networkClientIdToUse,
-            chainId: pendingSmartTransaction.chainId as Hex, // same as the key, but explicit on the transaction
+            chainId: chainId as Hex,
           };
         });
 
       if (pendingTransactions.length > 0) {
-        // Since each group is per chain, all transactions share the same chainId.
+        // Fetch status updates for all pending transactions on this chain
         await this.fetchSmartTransactionsStatus(pendingTransactions);
       }
     }


### PR DESCRIPTION
Thanks for reviewing! Here's what you need to know about these changes:

**Current State and Need for Change:**
* Currently, when users have a pending Smart Transaction (STX) and switch to a different network, the STX status fails to update
* Users must switch back to the original network (Ethereum or BNB) to see status updates
* This blocks users from initiating new transactions on other networks until they switch back
* The root cause is that we're using the transaction's chainId instead of the storage key's chainId when fetching status updates

**Solution:**
* Modified `updateSmartTransactions` to consistently use the storage key's chainId instead of the transaction's chainId
* Added comprehensive tests to verify status updates work correctly across multiple networks
* The fix ensures that STX status updates happen regardless of which network the user is currently on
* Users can now freely switch networks without losing track of their pending transactions

**Related Issues:**
* Fixes MetaMask/metamask-extension#31310
* This is the smart-transactions-controller portion of the fix for the extension issue

The changes are minimal but resolve a significant UX pain point where users were forced to switch back to original networks to see transaction status updates.
