### PR TITLE
feat: Add Arbitrum URL for Sentinel

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const SENTINEL_API_BASE_URL_MAP: SentinelApiBaseUrlMap = {
   1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
   56: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
   8453: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
+  42161: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
   11155111: 'https://tx-sentinel-ethereum-sepolia.api.cx.metamask.io',
 };
 


### PR DESCRIPTION
## Description
Add Arbitrum URL for Sentinel, so calls to its health API (and other APIs later) work properly.