### PR TITLE
feat: Get Sentinel URL and supported chain IDs dynamically

### DIFF
--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -415,7 +415,7 @@ describe('SmartTransactionsController', () => {
       await withController(
         {
           options: {
-            supportedChainIds: [ChainId.mainnet],
+            getSupportedChainIds: () => [ChainId.mainnet],
           },
         },
         ({ controller, triggerNetworStateChange }) => {
@@ -1889,7 +1889,7 @@ describe('SmartTransactionsController', () => {
       await withController(
         {
           options: {
-            // pending transactions in state are required to test polling
+            getSupportedChainIds: () => [ChainId.mainnet, ChainId.sepolia],
             state: {
               smartTransactionsState: {
                 ...getDefaultSmartTransactionsControllerState()
@@ -2009,7 +2009,7 @@ describe('SmartTransactionsController', () => {
       await withController(
         {
           options: {
-            // pending transactions in state are required to test polling
+            getSupportedChainIds: () => [ChainId.mainnet],
             state: {
               smartTransactionsState: {
                 ...getDefaultSmartTransactionsControllerState()
@@ -2186,12 +2186,10 @@ describe('SmartTransactionsController', () => {
       );
     });
 
-    it('removes transactions from the current chainId (even if it is not in supportedChainIds) if ignoreNetwork is false', async () => {
+    it('removes transactions from the current chainId (even if it is not returned by getSupportedChainIds) if ignoreNetwork is false', async () => {
       await withController(
         {
           options: {
-            supportedChainIds: [ChainId.sepolia],
-            chainId: ChainId.mainnet,
             state: {
               smartTransactionsState: {
                 ...getDefaultSmartTransactionsControllerState()
@@ -2238,11 +2236,11 @@ describe('SmartTransactionsController', () => {
       );
     });
 
-    it('removes transactions from all chains (even if they are not in supportedChainIds) if ignoreNetwork is true', async () => {
+    it('removes transactions from all chains (even if they are not returned by getSupportedChainIds) if ignoreNetwork is true', async () => {
       await withController(
         {
           options: {
-            supportedChainIds: [],
+            getSupportedChainIds: () => [],
             state: {
               smartTransactionsState: {
                 ...getDefaultSmartTransactionsControllerState()

--- a/src/SmartTransactionsController.test.ts
+++ b/src/SmartTransactionsController.test.ts
@@ -1141,6 +1141,26 @@ describe('SmartTransactionsController', () => {
       });
     });
 
+    it('fetches liveness using custom getSentinelUrl', async () => {
+      const customSentinelUrl = 'https://custom-sentinel.example.com';
+      await withController(
+        {
+          options: {
+            getSentinelUrl: (_chainId: Hex) => customSentinelUrl,
+          },
+        },
+        async ({ controller }) => {
+          nock(customSentinelUrl)
+            .get(`/network`)
+            .reply(200, createSuccessLivenessApiResponse());
+
+          const liveness = await controller.fetchLiveness();
+
+          expect(liveness).toBe(true);
+        },
+      );
+    });
+
     it('fetches liveness and sets in feesByChainId state for the Smart Transactions API for the chainId of the networkClientId passed in', async () => {
       await withController(async ({ controller }) => {
         nock(SENTINEL_API_BASE_URL_MAP[sepoliaChainIdDec])

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -621,4 +621,24 @@ describe('src/utils.js', () => {
       expect(updateTransactionMock).not.toHaveBeenCalled();
     });
   });
+
+  describe('getSentinelBaseUrl', () => {
+    it('returns the correct base URL for Ethereum Mainnet', () => {
+      const chainId = ChainId.mainnet;
+      const result = utils.getSentinelBaseUrl(chainId);
+      expect(result).toBe(SENTINEL_API_BASE_URL_MAP[parseInt(ChainId.mainnet, 16)]);
+    });
+
+    it('returns the correct base URL for Sepolia', () => {
+      const chainId = ChainId.sepolia;
+      const result = utils.getSentinelBaseUrl(chainId);
+      expect(result).toBe(SENTINEL_API_BASE_URL_MAP[parseInt(ChainId.sepolia, 16)]);
+    });
+
+    it('returns undefined for unsupported chainId', () => {
+      const unsupportedChainId = '0x999'; // Arbitrary unsupported chain
+      const result = utils.getSentinelBaseUrl(unsupportedChainId);
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,37 +36,46 @@ export const isSmartTransactionStatusResolved = (
 ) => stxStatus === 'uuid_not_found';
 
 // TODO use actual url once API is defined
-export function getAPIRequestURL(apiType: APIType, chainId: string): string {
+export function getAPIRequestURL(
+  apiType: APIType,
+  chainId: string,
+  sentinelUrl?: string,
+): string {
   const chainIdDec = parseInt(chainId, 16);
   switch (apiType) {
+    case APIType.LIVENESS: {
+      const effectiveSentinelUrl: string | undefined =
+        sentinelUrl ?? getSentinelBaseUrl(chainId);
+
+      if (effectiveSentinelUrl === undefined) {
+        throw new Error(`No sentinel URL for chainId ${chainId}`);
+      }
+      return `${effectiveSentinelUrl}/network`;
+    }
     case APIType.GET_FEES: {
       return `${API_BASE_URL}/networks/${chainIdDec}/getFees`;
     }
-
     case APIType.ESTIMATE_GAS: {
       return `${API_BASE_URL}/networks/${chainIdDec}/estimateGas`;
     }
-
     case APIType.SUBMIT_TRANSACTIONS: {
       return `${API_BASE_URL}/networks/${chainIdDec}/submitTransactions?stxControllerVersion=${packageJson.version}`;
     }
-
     case APIType.CANCEL: {
       return `${API_BASE_URL}/networks/${chainIdDec}/cancel`;
     }
-
     case APIType.BATCH_STATUS: {
       return `${API_BASE_URL}/networks/${chainIdDec}/batchStatus`;
     }
-
-    case APIType.LIVENESS: {
-      return `${SENTINEL_API_BASE_URL_MAP[chainIdDec]}/network`;
-    }
-
     default: {
-      throw new Error(`Invalid APIType`); // It can never get here thanks to TypeScript.
+      throw new Error(`Invalid APIType`);
     }
   }
+}
+
+export function getSentinelBaseUrl(chainId: string): string | undefined {
+  const chainIdDec = parseInt(chainId, 16);
+  return SENTINEL_API_BASE_URL_MAP[chainIdDec];
 }
 
 export const calculateStatus = (stxStatus: SmartTransactionsStatus) => {


### PR DESCRIPTION
## Description
This PR allows us to:
- Call the `getSentinelUrl` function with a chainId to get the right Sentinel URL. With this we no longer need to make changes in this codebase when adding a new network.
- Call the `getSupportedChainIds` function, which will return a list of supported chain IDs based on their availability in remote-api-config.