### PR TITLE
chore: Don't persist controller state

### DIFF
--- a/src/SmartTransactionsController.ts
+++ b/src/SmartTransactionsController.ts
@@ -77,7 +77,7 @@ const controllerName = 'SmartTransactionsController';
 
 const controllerMetadata = {
   smartTransactionsState: {
-    persist: true,
+    persist: false,
     anonymous: true,
   },
 };


### PR DESCRIPTION
## Description
It will clean up controller state when the browser / app re-opens. We don't need to persist it since we update transaction state in TransactionController. Also, it worked well with `persist: false` before for a long time.
