### PR TITLE
Upgrade `transaction-controller` peer dep to v60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Disallow subpath exports ([#469](https://github.com/MetaMask/smart-transactions-controller/pull/469))
-- Update `@metamask/base-controller` from `^7.0.1` to `^8.3.0` ([#529](https://github.com/MetaMask/smart-transactions-controller/pull/529))
-- Update `@metamask/polling-controller` from `^12.0.0` to `^14.0.0` ([#529](https://github.com/MetaMask/smart-transactions-controller/pull/529))
+- **BREAKING:** Upgrade peer dependency `@metamask/transaction-controller` from `^58.0.0` to `^60.3.0`
+- Upgrade `@metamask/base-controller` from `^7.0.1` to `^8.3.0` ([#529](https://github.com/MetaMask/smart-transactions-controller/pull/529))
+- Upgrade `@metamask/polling-controller` from `^12.0.0` to `^14.0.0` ([#529](https://github.com/MetaMask/smart-transactions-controller/pull/529))
 
 ## [18.1.0]
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@metamask/gas-fee-controller": "^22.0.0",
     "@metamask/json-rpc-engine": "^10.0.1",
     "@metamask/network-controller": "^24.0.0",
-    "@metamask/transaction-controller": "^58.1.0",
+    "@metamask/transaction-controller": "^60.3.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.194",
@@ -93,13 +93,22 @@
   },
   "peerDependencies": {
     "@metamask/network-controller": "^24.0.0",
-    "@metamask/transaction-controller": "^58.0.0"
+    "@metamask/transaction-controller": "^60.0.0"
   },
   "peerDependenciesMeta": {
     "@metamask/accounts-controller": {
       "optional": true
     },
     "@metamask/approval-controller": {
+      "optional": true
+    },
+    "@metamask/eth-block-tracker": {
+      "optional": true
+    },
+    "@metamask/gas-fee-controller": {
+      "optional": true
+    },
+    "@metamask/remote-feature-flag-controller": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,28 +1435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.10.0, @metamask/controller-utils@npm:^11.4.2, @metamask/controller-utils@npm:^11.4.3":
-  version: 11.10.0
-  resolution: "@metamask/controller-utils@npm:11.10.0"
-  dependencies:
-    "@ethereumjs/util": ^9.1.0
-    "@metamask/eth-query": ^4.0.0
-    "@metamask/ethjs-unit": ^0.3.0
-    "@metamask/utils": ^11.2.0
-    "@spruceid/siwe-parser": 2.1.0
-    "@types/bn.js": ^5.1.5
-    bignumber.js: ^9.1.2
-    bn.js: ^5.2.1
-    cockatiel: ^3.1.2
-    eth-ens-namehash: ^2.0.8
-    fast-deep-equal: ^3.1.3
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-  checksum: b6b1b3ed6b963a21dcb6c0eb9779a4e4d66b6dab7459cee18fc75db7e66a8b717e6b3095a1a981f102321ff9ebcb7eb2e842af863ef546334bd6b602e61fd77e
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^11.12.0":
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.10.0, @metamask/controller-utils@npm:^11.12.0, @metamask/controller-utils@npm:^11.4.2, @metamask/controller-utils@npm:^11.4.3":
   version: 11.12.0
   resolution: "@metamask/controller-utils@npm:11.12.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/controller-utils@npm:^11.12.0":
+  version: 11.12.0
+  resolution: "@metamask/controller-utils@npm:11.12.0"
+  dependencies:
+    "@metamask/eth-query": ^4.0.0
+    "@metamask/ethjs-unit": ^0.3.0
+    "@metamask/utils": ^11.4.2
+    "@spruceid/siwe-parser": 2.1.0
+    "@types/bn.js": ^5.1.5
+    bignumber.js: ^9.1.2
+    bn.js: ^5.2.1
+    cockatiel: ^3.1.2
+    eth-ens-namehash: ^2.0.8
+    fast-deep-equal: ^3.1.3
+    lodash: ^4.17.21
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+  checksum: a96dea30d56676c3070d118d4e130f6f97c2ddeac1161d49a99f114af7ca6e9b87f955ea5a6a17c72410243cf9eafed5748474144013b548955b9edc7e97b409
+  languageName: node
+  linkType: hard
+
 "@metamask/eslint-config-jest@npm:^12.1.0":
   version: 12.1.0
   resolution: "@metamask/eslint-config-jest@npm:12.1.0"
@@ -1847,7 +1868,7 @@ __metadata:
     "@metamask/json-rpc-engine": ^10.0.1
     "@metamask/network-controller": ^24.0.0
     "@metamask/polling-controller": ^14.0.0
-    "@metamask/transaction-controller": ^58.1.0
+    "@metamask/transaction-controller": ^60.3.0
     "@ts-bridge/cli": ^0.6.3
     "@types/jest": ^26.0.24
     "@types/lodash": ^4.14.194
@@ -1876,11 +1897,17 @@ __metadata:
     typescript: ~4.8.4
   peerDependencies:
     "@metamask/network-controller": ^24.0.0
-    "@metamask/transaction-controller": ^58.0.0
+    "@metamask/transaction-controller": ^60.0.0
   peerDependenciesMeta:
     "@metamask/accounts-controller":
       optional: true
     "@metamask/approval-controller":
+      optional: true
+    "@metamask/eth-block-tracker":
+      optional: true
+    "@metamask/gas-fee-controller":
+      optional: true
+    "@metamask/remote-feature-flag-controller":
       optional: true
   languageName: unknown
   linkType: soft
@@ -1899,9 +1926,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^58.1.0":
-  version: 58.1.0
-  resolution: "@metamask/transaction-controller@npm:58.1.0"
+"@metamask/transaction-controller@npm:^60.3.0":
+  version: 60.3.0
+  resolution: "@metamask/transaction-controller@npm:60.3.0"
   dependencies:
     "@ethereumjs/common": ^4.4.0
     "@ethereumjs/tx": ^5.4.0
@@ -1910,13 +1937,13 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@ethersproject/wallet": ^5.7.0
-    "@metamask/base-controller": ^8.0.1
-    "@metamask/controller-utils": ^11.10.0
+    "@metamask/base-controller": ^8.3.0
+    "@metamask/controller-utils": ^11.12.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/metamask-eth-abis": ^3.1.1
     "@metamask/nonce-tracker": ^6.0.0
     "@metamask/rpc-errors": ^7.0.2
-    "@metamask/utils": ^11.2.0
+    "@metamask/utils": ^11.4.2
     async-mutex: ^0.5.0
     bn.js: ^5.2.1
     eth-method-registry: ^4.0.0
@@ -1925,13 +1952,13 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^31.0.0
+    "@metamask/accounts-controller": ^33.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
     "@metamask/gas-fee-controller": ^24.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 16d866283490ef146653429a32b9f147eb772e26baf990c6b559638843b2dc5c33975c68b743d02788b99b38ea2772b01ba44d3448e4a6af0e82e16bebd8aad2
+  checksum: 910475ae2a20279d1743a6331b178a22a5416ecabcf4b9391defb2c8753b6963e1e34e55f6fd50bc2740f468ebc636e864722d8d7607d18b750bb1c2edb844a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There have been some changes to the `TransactionMeta` package but there should be no functional changes to this package.

Changelog here: https://github.com/MetaMask/core/blob/71b6bb6530f363d36475ca3d8f6029595fe508bd/packages/transaction-controller/CHANGELOG.md