### PR TITLE
chore: add migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over. Also, please re-open PRs that are under active development in the core repo.</p></td></tr></table>
+
 # `@metamask/smart-transactions-controller`
 
 Improves success rates for swaps by trialing transactions privately and finding minimum fees.


### PR DESCRIPTION
## Summary

- This package is being migrated into the [`core` monorepo](https://github.com/MetaMask/core).
- Per the [package migration process guide](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md#pr1-1-add-the-following-migration-notice-to-the-readme), Phase A step 1 is to prepend the standard ⚠️ PLEASE READ ⚠️ notice to `README.md` so that contributors know not to push new work here while the migration is in flight.

## Test plan

- [x] Render `README.md` on GitHub and confirm the notice displays as a centered table at the top of the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or package behavior impact.
> 
> **Overview**
> Prepends the standard MetaMask **core monorepo migration** notice to `README.md` as a centered HTML table at the top of the file.
> 
> The notice tells contributors not to commit here during migration and to reopen in-flight PRs in the `core` repo; existing README content is unchanged aside from a blank line after the notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31caf0340a97cef54285441a252e483b4926b24c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->