### PR TITLE
chore: add typedoc.json configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `typedoc.json` configuration for API doc generation ([#TBD](https://github.com/MetaMask/smart-transactions-controller/pull/TBD))
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `typedoc.json` configuration for API doc generation ([#TBD](https://github.com/MetaMask/smart-transactions-controller/pull/TBD))
+- Add `typedoc.json` configuration for API doc generation ([#592](https://github.com/MetaMask/smart-transactions-controller/pull/592))
 
 ### Changed
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}


### PR DESCRIPTION
## Explanation

Adds the TypeDoc configuration file expected by the MetaMask core monorepo's package conventions ([scripts/create-package/package-template/typedoc.json](https://github.com/MetaMask/core/blob/main/scripts/create-package/package-template/typedoc.json)).

The file is a static configuration — no wiring is added here because the source repo doesn't currently consume it. TypeDoc tooling (and a `build:docs` script) will be enabled once the package lands in core (Phase B PR #9 of the [migration guide](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md)).

## References

- Migration plan: Phase A PR #3 (add files missing vs `metamask-module-template`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static documentation config and changelog only; no runtime or build behavior changes in this repository.
> 
> **Overview**
> Adds a **`typedoc.json`** config aligned with MetaMask core package conventions so API docs can be generated from `./src/index.ts` into `docs`, using `tsconfig.build.json`, hiding private symbols and the TypeDoc generator banner.
> 
> Documents the addition under **Unreleased → Added** in `CHANGELOG.md`. No `build:docs` script or TypeDoc dependency is wired in this repo yet; that is expected to follow when the package lands in core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2395cc2fc5c7122dca3ba7891f8ec9d0a1b081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->