### PR TITLE
chore: relicense package under MIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Relicense the package under the MIT License, replacing the previous ConsenSys non-commercial license ([#TBD](https://github.com/MetaMask/smart-transactions-controller/pull/TBD))
+- **BREAKING:** Relicense the package under the MIT License, replacing the previous ConsenSys non-commercial license ([#593](https://github.com/MetaMask/smart-transactions-controller/pull/593))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))
 - Bump `@metamask/profile-sync-controller` from `^28.1.0` to `^28.1.1` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))
 - Bump `@metamask/remote-feature-flag-controller` from `^4.2.1` to `^4.2.2` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Relicense the package under the MIT License, replacing the previous ConsenSys non-commercial license ([#TBD](https://github.com/MetaMask/smart-transactions-controller/pull/TBD))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))
 - Bump `@metamask/profile-sync-controller` from `^28.1.0` to `^28.1.1` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))
 - Bump `@metamask/remote-feature-flag-controller` from `^4.2.1` to `^4.2.2` ([#590](https://github.com/MetaMask/smart-transactions-controller/pull/590))

--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,20 @@
-Copyright ConsenSys Software Inc. 2020. All rights reserved.
- 
-You acknowledge and agree that ConsenSys Software Inc. (“ConsenSys”) (or ConsenSys’s licensors) own all legal right, title and interest in and to the work, software, application, source code, documentation and any other documents in this repository (collectively, the “Program”), including any intellectual property rights which subsist in the Program (whether those rights happen to be registered or not, and wherever in the world those rights may exist), whether in source code or any other form.
- 
-Subject to the limited license below, you may not (and you may not permit anyone else to) distribute, publish, copy, modify, merge, combine with another program, create derivative works of, reverse engineer, decompile or otherwise attempt to extract the source code of, the Program or any part thereof, except that you may contribute to this repository.
- 
-You are granted a non-exclusive, non-transferable, non-sublicensable license to distribute, publish, copy, modify, merge, combine with another program or create derivative works of the Program (such resulting program, collectively, the “Resulting Program”) solely for Non-Commercial Use as long as you:
- 1. give prominent notice (“Notice”) with each copy of the Resulting Program that the Program is used in the Resulting Program and that the Program is the copyright of ConsenSys; and
- 2. subject the Resulting Program and any distribution, publication, copy, modification, merger therewith, combination with another program or derivative works thereof to the same Notice requirement and Non-Commercial Use restriction set forth herein.
- 
-“Non-Commercial Use” means each use as described in clauses (1)-(3) below, as reasonably determined by ConsenSys in its sole discretion: 
- 1. personal use for research, personal study, private entertainment, hobby projects or amateur pursuits, in each case without any anticipated commercial application;
- 2. use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization or government institution; or
- 3. the number of monthly active users of the Resulting Program across all versions thereof and platforms globally do not exceed 10,000 at any time.
- 
-You will not use any trade mark, service mark, trade name, logo of ConsenSys or any other company or organization in a way that is likely or intended to cause confusion about the owner or authorized user of such marks, names or logos.
- 
-If you have any questions, comments or interest in pursuing any other use cases, please reach out to us at metamask.license@consensys.net.
+MIT License
+
+Copyright (c) 2018 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/smart-transactions-controller.git"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "sideEffects": false,
   "exports": {
     ".": {


### PR DESCRIPTION
## Explanation

> [!IMPORTANT]
> This PR changes the license of the package. Confirm legal sign-off before merging.

Replaces the previous ConsenSys non-commercial license with the **MIT License**, matching the canonical `LICENSE` file used across all packages in the [`MetaMask/core`](https://github.com/MetaMask/core) monorepo. The `LICENSE` file content is byte-for-byte identical to e.g. [`packages/transaction-controller/LICENSE`](https://github.com/MetaMask/core/blob/main/packages/transaction-controller/LICENSE) (md5 `972abebacc3cb2abb10cd3dae0dd97a3`).

Also updates `package.json` `license` field: `SEE LICENSE IN LICENSE` → `MIT`.

### Why

Required so that [`yarn constraints`](https://github.com/MetaMask/core/blob/main/yarn.config.cjs) passes when this package is migrated into core (Phase B PR #10 of the [package migration process guide](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md)). The constraint expects `license: "MIT"` for non-root packages by default.

## References

- Migration plan: tied to Phase A PR #3 follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> License change is legally significant for downstream use and redistribution; runtime behavior is unchanged but consumers must review compliance before upgrading.
> 
> **Overview**
> **BREAKING:** Relicenses `@metamask/smart-transactions-controller` from the ConsenSys non-commercial terms to the standard MetaMask **MIT** `LICENSE` (aligned with other `MetaMask/core` packages).
> 
> Updates `package.json` `license` from `SEE LICENSE IN LICENSE` to `MIT`, and records the change under **Unreleased → Changed** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f2e3ad957a70ed37759138de329103a6a81029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->