### PR TITLE
chore: replace migration notice with archived notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over. Also, please re-open PRs that are under active development in the core repo.</p></td></tr></table>
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package has been migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo, and this repository has been archived. Please note that all future development and feature releases will take place in the <a href="https://github.com/MetaMask/core"><code>core</code></a> repository.</p></td></tr></table>
 
 # `@metamask/smart-transactions-controller`
 


### PR DESCRIPTION
## Explanation

Final cleanup step of the migration to [`MetaMask/core`](https://github.com/MetaMask/core) ([package migration process guide, Phase D step 3](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md#source-repo)).

Replaces the "migration in progress" notice at the top of `README.md` with the standard "archived" notice. The package now lives at [`MetaMask/core/packages/smart-transactions-controller`](https://github.com/MetaMask/core/tree/main/packages/smart-transactions-controller); all future development and releases happen from there.

This is the last commit landing on this repo before it gets archived by a `@MetaMask/engineering` maintainer.

## References

- Core migration PR (Phase C #12): https://github.com/MetaMask/core/pull/9139
- Final release from this repo: [`v24.2.1`](https://github.com/MetaMask/smart-transactions-controller/releases/tag/v24.2.1)